### PR TITLE
Configuração do projeto com teste de injeção

### DIFF
--- a/Testes/ModuloDeInjecao.cs
+++ b/Testes/ModuloDeInjecao.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Testes
+{
+    public class ModuloDeInjecao
+    {
+    }
+}

--- a/Testes/TesteBase.cs
+++ b/Testes/TesteBase.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Testes
+{
+    public class TesteBase : IDisposable
+    {
+        protected ServiceProvider _serviceProvider;
+
+        public TesteBase(ServiceProvider ServiceProvider)
+        {
+            _serviceProvider = ServiceProvider;
+        }
+
+        public void Dispose()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/Testes/Testes.csproj
+++ b/Testes/Testes.csproj
@@ -10,8 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
     <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Xunit.Microsoft.DependencyInjection" Version="7.0.10" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Foi instalado o pacote NuGet do Xunit de Injeção de Dependência, criado classe TesteBase que herda IDisposable e criado a propriedade ServiceProvider do tipo ServiceProvider para obter os serviços injetados.