### PR TITLE
Implementar tela de edicao para registro pai

### DIFF
--- a/Cod3rsGrowth.Web/Cod3rsGrowth.Web.csproj.user
+++ b/Cod3rsGrowth.Web/Cod3rsGrowth.Web.csproj.user
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Controller_SelectedScaffolderID>ApiControllerEmptyScaffolder</Controller_SelectedScaffolderID>
     <Controller_SelectedScaffolderCategoryPath>root/Common/Api</Controller_SelectedScaffolderCategoryPath>
-    <ActiveDebugProfile>https-Teste</ActiveDebugProfile>
+    <ActiveDebugProfile>https</ActiveDebugProfile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>

--- a/Cod3rsGrowth.Web/Cod3rsGrowth.Web.csproj.user
+++ b/Cod3rsGrowth.Web/Cod3rsGrowth.Web.csproj.user
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Controller_SelectedScaffolderID>ApiControllerEmptyScaffolder</Controller_SelectedScaffolderID>
     <Controller_SelectedScaffolderCategoryPath>root/Common/Api</Controller_SelectedScaffolderCategoryPath>
-    <ActiveDebugProfile>https</ActiveDebugProfile>
+    <ActiveDebugProfile>https-Teste</ActiveDebugProfile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>

--- a/Cod3rsGrowth.Web/Controllers/PersonagemController.cs
+++ b/Cod3rsGrowth.Web/Controllers/PersonagemController.cs
@@ -61,8 +61,8 @@ namespace Cod3rsGrowth.Web.Controllers
         [HttpPut("personagem")]
         public IActionResult Editar([FromBody] Personagem personagem)
         {
-            _servicoPersonagem.Editar(personagem);
-            return Ok();
+            var idPersonagem = _servicoPersonagem.Editar(personagem);
+            return Ok(idPersonagem);
         }
         [HttpDelete("personagem")]
         public IActionResult Deletar([FromBody] int id)

--- a/Cod3rsGrowth.Web/Controllers/RacaController.cs
+++ b/Cod3rsGrowth.Web/Controllers/RacaController.cs
@@ -34,7 +34,7 @@ namespace Cod3rsGrowth.Web.Controllers
         public IActionResult Criar([FromBody] Raca raca)
         {
             var idRaca = _servicoRaca.Criar(raca);
-            return Ok(idRaca);
+            return Ok();
         }
         [HttpPut("raca")]
         public IActionResult Editar([FromBody] Raca raca)

--- a/Cod3rsGrowth.Web/wwwroot/i18n/i18n.properties
+++ b/Cod3rsGrowth.Web/wwwroot/i18n/i18n.properties
@@ -98,7 +98,6 @@ PlaceholderLocalizacaoGeografica = Geographic location...
 
 #Editar Raça Pagina
 TituloPaginaEditarRaca = Edit Race
-BotaoEditar = Edit
 
 #Detalhes Raça
 TituloPaginaDetalhesRaca = Race Details

--- a/Cod3rsGrowth.Web/wwwroot/i18n/i18n.properties
+++ b/Cod3rsGrowth.Web/wwwroot/i18n/i18n.properties
@@ -99,3 +99,4 @@ PlaceholderLocalizacaoGeografica = Geographic location...
 #Detalhes Raça
 TituloPaginaDetalhesRaca = Race Details
 LabelId = Id
+BotaoEditar = Edit

--- a/Cod3rsGrowth.Web/wwwroot/i18n/i18n.properties
+++ b/Cod3rsGrowth.Web/wwwroot/i18n/i18n.properties
@@ -96,6 +96,10 @@ radioBtnNaoExtinta = Active
 PlaceholHabilidadeRacial = Racial Ability...
 PlaceholderLocalizacaoGeografica = Geographic location...
 
+#Editar Raça Pagina
+TituloPaginaEditarRaca = Edit Race
+BotaoEditar = Edit
+
 #Detalhes Raça
 TituloPaginaDetalhesRaca = Race Details
 LabelId = Id

--- a/Cod3rsGrowth.Web/wwwroot/i18n/i18n_pt_br.properties
+++ b/Cod3rsGrowth.Web/wwwroot/i18n/i18n_pt_br.properties
@@ -99,4 +99,5 @@ PlaceholderLocalizacaoGeografica = Localização Geográfica...
 
 #Detalhes Raça
 TituloPaginaDetalhesRaca = Detalhes da Raça
-LabelId = Id   
+LabelId = Id
+BotaoEditar = Editar

--- a/Cod3rsGrowth.Web/wwwroot/i18n/i18n_pt_br.properties
+++ b/Cod3rsGrowth.Web/wwwroot/i18n/i18n_pt_br.properties
@@ -97,6 +97,10 @@ radioBtnNaoExtinta = Ativa
 PlaceholHabilidadeRacial = Habilidade Racial...
 PlaceholderLocalizacaoGeografica = Localização Geográfica...
 
+#Editar Raça Pagina
+TituloPaginaEditarRaca = Editar Raça
+BotaoEditar = Editar
+
 #Detalhes Raça
 TituloPaginaDetalhesRaca = Detalhes da Raça
 LabelId = Id

--- a/Cod3rsGrowth.Web/wwwroot/test/integration/AllJourneys.js
+++ b/Cod3rsGrowth.Web/wwwroot/test/integration/AllJourneys.js
@@ -7,6 +7,7 @@ sap.ui.define(
     "./journeys/ListaRacasJourney",
     "./journeys/CriarPersonagemJourney",
     "./journeys/CriarRacaJourney",
+    "./journeys/EditarRacaJourney",
     "./journeys/DetalhesRacaJourney",
   ],
   function (Opa5, Startup) {

--- a/Cod3rsGrowth.Web/wwwroot/test/integration/journeys/DetalhesRacaJourney.js
+++ b/Cod3rsGrowth.Web/wwwroot/test/integration/journeys/DetalhesRacaJourney.js
@@ -26,7 +26,7 @@ sap.ui.define(
         //Cleanup
         Then.iTeardownMyApp();
       }
-    ),
+    );
       opaTest(
         "Deve carregar a página de notFound quando o ID da raça não existir",
         function (Given, When, Then) {
@@ -41,7 +41,7 @@ sap.ui.define(
           //Cleanup;
           Then.iTeardownMyApp();
         }
-      ),
+      );
       opaTest(
         "Deve navegar para a págima home ao pressionar o botão voltar",
         function (Given, When, Then) {
@@ -61,6 +61,26 @@ sap.ui.define(
           //Cleanup
           Then.iTeardownMyApp();
         }
+      );
+      opaTest(
+          "Deve navegar até a página de edição da raça",
+          function (Given, When, Then) {
+              //Arrangements
+              Given.iStartMyApp({
+                  hash: "raca/1",
+              });
+
+              //Actions
+              When.naPaginaDeDetalhesDaRaca.euPressionoBotaoEditar();
+
+              //Assertions
+              Then.naPaginaDeEditarRaca.aTelaDeEdicaoFoiCarregadaCorretamente()
+                  .and.oBotaoEditarTemONomeCorreto()
+                  .and.osInputDeNomeDeveEstarPreenchido("Humano");
+
+              //Cleanup
+              Then.iTeardownMyApp();
+          }
       );
   }
 );

--- a/Cod3rsGrowth.Web/wwwroot/test/integration/journeys/EditarRacaJourney.js
+++ b/Cod3rsGrowth.Web/wwwroot/test/integration/journeys/EditarRacaJourney.js
@@ -1,0 +1,169 @@
+sap.ui.define(
+    [
+        "sap/ui/test/opaQunit",
+        "../pages/EditarRaca",
+        "../pages/ListaRacas",
+        "../pages/Home",
+    ],
+    function (opaTest) {
+        "use strict";
+
+        QUnit.module("Editar Raça");
+
+        opaTest(
+            "Deve retornar um erro ao editar um raça com o nome já cadastrado em outra raça",
+            function (Given, When, Then) {
+                // Arrangements
+                Given.iStartMyApp({
+                    hash: "raca/editarRaca/1",
+                });
+
+                //Actions
+                When.naPaginaDeEditarRaca.aTelaFoiCarregadaCorretamente();
+                When.naPaginaDeEditarRaca.euDigitoUmNomeNoInputField("Elfo");
+                When.naPaginaDeEditarRaca.euDigitoUmaLocalizacaoGeograficaNoInputField(
+                    "???"
+                );
+                When.naPaginaDeEditarRaca.euDigitoUmaHabilidadeRacialNoInputField("???");
+                When.naPaginaDeEditarRaca.euSelecionoCondicaoNaoExtinta();
+                When.naPaginaDeEditarRaca.euPressionoOBotaoEditar();
+
+                // Assertions
+                Then.naPaginaDeEditarRaca.deveAparecerUmaMessageBoxDeErroVindoDoServidor();
+                // Cleanup
+                Then.iTeardownMyApp();
+            }
+        );
+        opaTest(
+            "Deve retornar um erro ao editar um raça sem preencher nenhum input field",
+            function (Given, When, Then) {
+                // Arrangements
+                Given.iStartMyApp({
+                    hash: "raca/editarRaca/1",
+                });
+                //Actions
+                When.naPaginaDeEditarRaca.aTelaFoiCarregadaCorretamente();
+                When.naPaginaDeEditarRaca.euDigitoUmNomeNoInputField("");
+                When.naPaginaDeEditarRaca.euDigitoUmaLocalizacaoGeograficaNoInputField(
+                    ""
+                );
+                When.naPaginaDeEditarRaca.euDigitoUmaHabilidadeRacialNoInputField("");
+                When.naPaginaDeEditarRaca.euPressionoOBotaoEditar();
+
+                // Assertions
+                Then.naPaginaDeEditarRaca.deveAparecerUmaMessageBoxDeErro();
+                // Cleanup
+                Then.iTeardownMyApp();
+            }
+        );
+        opaTest(
+            "Deve retornar um erro ao editar um raça com o nome menor que 3 caracteres",
+            function (Given, When, Then) {
+                // Arrangements
+                Given.iStartMyApp({
+                    hash: "raca/editarRaca/1",
+                });
+                //Actions
+                When.naPaginaDeEditarRaca.aTelaFoiCarregadaCorretamente();
+                When.naPaginaDeEditarRaca.euDigitoUmNomeNoInputField("Al");
+                When.naPaginaDeEditarRaca.euDigitoUmaLocalizacaoGeograficaNoInputField(
+                    "???"
+                );
+                When.naPaginaDeEditarRaca.euDigitoUmaHabilidadeRacialNoInputField("???");
+                When.naPaginaDeEditarRaca.euSelecionoCondicaoNaoExtinta();
+                When.naPaginaDeEditarRaca.euPressionoOBotaoEditar();
+
+                // Assertions
+                Then.naPaginaDeEditarRaca.deveAparecerUmaMessageBoxDeErro();
+                // Cleanup
+                Then.iTeardownMyApp();
+            }
+        );
+        opaTest(
+            "Deve retornar um erro ao editar um raça com o nome com caracteres invalidos",
+            function (Given, When, Then) {
+                // Arrangements
+                Given.iStartMyApp({
+                    hash: "raca/editarRaca/1",
+                });
+                //Actions
+                When.naPaginaDeEditarRaca.aTelaFoiCarregadaCorretamente();
+                When.naPaginaDeEditarRaca.euDigitoUmNomeNoInputField("****");
+                When.naPaginaDeEditarRaca.euDigitoUmaLocalizacaoGeograficaNoInputField(
+                    "???"
+                );
+                When.naPaginaDeEditarRaca.euDigitoUmaHabilidadeRacialNoInputField("???");
+                When.naPaginaDeEditarRaca.euSelecionoCondicaoNaoExtinta();
+                When.naPaginaDeEditarRaca.euSelecionoCondicaoExinta();
+                When.naPaginaDeEditarRaca.euPressionoOBotaoEditar();
+
+                // Assertions
+                Then.naPaginaDeEditarRaca.deveAparecerUmaMessageBoxDeErro();
+                // Cleanup
+                Then.iTeardownMyApp();
+            }
+        );
+        opaTest(
+            "Deve retornar a pagina de listagem de raças quando pressiono o botao cancelar",
+            function (Given, When, Then) {
+                // Arrangements
+                Given.iStartMyApp({
+                    hash: "raca/editarRaca/1",
+                });
+                //Actions
+                When.naPaginaDeEditarRaca.aTelaFoiCarregadaCorretamente();
+                When.naPaginaDeEditarRaca.euPressionoOBotaoCancelar();
+
+                // Assertions
+                Then.naPaginaDaListaDeRacas
+                    .oTituloDaPaginaDeRacasDeveraSer()
+                    .and.aUrlDaPaginaDeRacasDeveraSer();
+                // Cleanup
+                Then.iTeardownMyApp();
+            }
+        );
+        opaTest(
+            "Deve retornar a pagina anterior quando pressiono o botao de voltar",
+            function (Given, When, Then) {
+                // Arrangements
+                Given.iStartMyApp({
+                    hash: "raca/editarRaca/1",
+                });
+                //Actions
+                When.naPaginaDeEditarRaca.aTelaFoiCarregadaCorretamente();
+                When.naPaginaDeEditarRaca.euPressionoBotaoVoltar();
+
+                // Assertions
+                Then.naPaginaDaListaDeRacas
+                    .oTituloDaPaginaDeRacasDeveraSer()
+                    .and.aUrlDaPaginaDeRacasDeveraSer();
+                // Cleanup
+                Then.iTeardownMyApp();
+            }
+        );
+        opaTest(
+            "Deve retornar um erro ao editar um raça com poucos caracteres e caracteres inválidos",
+            function (Given, When, Then) {
+                // Arrangements
+                Given.iStartMyApp({
+                    hash: "raca/editarRaca/1",
+                });
+                //Actions
+                When.naPaginaDeEditarRaca.aTelaFoiCarregadaCorretamente();
+                When.naPaginaDeEditarRaca.euDigitoUmNomeNoInputField("D*");
+                When.naPaginaDeEditarRaca.euDigitoUmaLocalizacaoGeograficaNoInputField(
+                    "???"
+                );
+                When.naPaginaDeEditarRaca.euDigitoUmaHabilidadeRacialNoInputField("???");
+                When.naPaginaDeEditarRaca.euSelecionoCondicaoNaoExtinta();
+                When.naPaginaDeEditarRaca.euPressionoOBotaoEditar();
+
+                // Assertions
+                Then.naPaginaDeEditarRaca.deveAparecerUmaMessageBoxDeErro();
+
+                // Cleanup
+                Then.iTeardownMyApp();
+            }
+        );
+    }
+);

--- a/Cod3rsGrowth.Web/wwwroot/test/integration/pages/CriarRaca.js
+++ b/Cod3rsGrowth.Web/wwwroot/test/integration/pages/CriarRaca.js
@@ -4,8 +4,9 @@ sap.ui.define(
     "sap/ui/test/actions/Press",
     "sap/ui/test/actions/EnterText",
     "sap/ui/test/matchers/PropertyStrictEquals",
+    "sap/ui/test/matchers/I18NText",
   ],
-  function (Opa5, Press, EnterText, PropertyStrictEquals) {
+  function (Opa5, Press, EnterText, PropertyStrictEquals, I18NText) {
     "use strict";
 
     const NOME_VIEW = "CriarRaca",
@@ -172,6 +173,34 @@ sap.ui.define(
               errorMessage: "A tela 'Home' não foi carregada corretamente",
             });
           },
+          aTelaDeEdicaoFoiCarregadaCorretamente: function (){
+            return this.waitFor({
+              controlType: "sap.m.Page",
+              matchers: new I18NText({
+                propertyName: "title",
+                key: "TituloPaginaEditarRaca",
+              }),
+              success: function (pagina) {
+                Opa5.assert.ok(pagina, "O título da página está correto.");
+              },
+              errorMessage:
+                  "Não foi encontrado título correspondente ou não foi possível navegar até a página",
+            });
+          },
+          oBotaoEditarTemONomeCorreto: function (){
+            return this.waitFor({
+              controlType: "sap.m.Button",
+              matchers: new I18NText({
+                propertyName: "text",
+                key: "BotaoEditar",
+              }),
+              success: function (botao) {
+                Opa5.assert.ok(botao, "O texto do botao na página está correto.");
+              },
+              errorMessage:
+                  "Não foi encontrado texto do botao correspondente ou não foi possível encontrar o botão em si",
+            });
+          }
         },
       },
     });

--- a/Cod3rsGrowth.Web/wwwroot/test/integration/pages/DetalhesRaca.js
+++ b/Cod3rsGrowth.Web/wwwroot/test/integration/pages/DetalhesRaca.js
@@ -22,6 +22,17 @@ sap.ui.define(
                 "Não foi possível encontrar o botão voltar na página",
             });
           },
+          euPressionoBotaoEditar: function (){
+            return this.waitFor({
+              controlType: "sap.m.Button",
+              matchers: new I18NText({
+                propertyName: "text",
+                key: "BotaoEditar"
+              }),
+              actions: new Press(),
+              errorMessage: "Não foi possível encontrar o botão editar na página",
+            });
+          },
         },
         assertions: {
           oTituloDaPaginaDetalhesDaRacaDeveraSer: function () {
@@ -37,7 +48,7 @@ sap.ui.define(
                     Opa5.assert.ok(pagina, "O título da página está correto.");
                   },
                   errorMessage:
-                    "Não foi encontrado título correspondente a 'O Senhor dos Anéis' ou não foi possível navegar até a página",
+                      "Não foi encontrado título correspondente a 'O Senhor dos Anéis' ou não foi possível navegar até a página",
                 });
               },
             });

--- a/Cod3rsGrowth.Web/wwwroot/test/integration/pages/EditarRaca.js
+++ b/Cod3rsGrowth.Web/wwwroot/test/integration/pages/EditarRaca.js
@@ -1,0 +1,222 @@
+sap.ui.define(
+    [
+        "sap/ui/test/Opa5",
+        "sap/ui/test/actions/Press",
+        "sap/ui/test/actions/EnterText",
+        "sap/ui/test/matchers/PropertyStrictEquals",
+        "sap/ui/test/matchers/I18NText",
+    ],
+    function (Opa5, Press, EnterText, PropertyStrictEquals, I18NText) {
+        "use strict";
+
+        const NOME_VIEW = "CriarRaca",
+            NOME_VIEW_HOME = "Home",
+            ID_PAGINA = "paginaCriarRaca",
+            ID_INPUT_NOME = "inputNome",
+            ID_INPUT_LOCALIZACAO_GEOGRAFICA = "inputLocalizacaoGeografica",
+            ID_INPUT_HABILIDADE_RACIAL = "inputHabilidadeRacial",
+            ID_RADIO_BUTTON_EXTINTA = "radioBtnExtinta",
+            ID_RADIO_BUTTON_NAO_EXTINTA = "radioBtnNaoExtinta";
+        Opa5.createPageObjects({
+            naPaginaDeEditarRaca: {
+                actions: {
+                    aTelaFoiCarregadaCorretamente: function () {
+                        return this.waitFor({
+                            viewName: NOME_VIEW,
+                            success: () =>
+                                Opa5.assert.ok(true, "A tela foi carregada corretamente"),
+                            errorMessage: "A tela não foi carregada corretamente",
+                        });
+                    },
+                    euDigitoUmNomeNoInputField: function (nomeRaca) {
+                        return this.waitFor({
+                            id: ID_INPUT_NOME,
+                            viewName: NOME_VIEW,
+                            actions: new EnterText({
+                                text: nomeRaca,
+                            }),
+                            errorMessage: "Input não encontrado",
+                        });
+                    },
+                    euDigitoUmaLocalizacaoGeograficaNoInputField: function (
+                        localizacaoGeografica
+                    ) {
+                        return this.waitFor({
+                            id: ID_INPUT_LOCALIZACAO_GEOGRAFICA,
+                            viewName: NOME_VIEW,
+                            actions: new EnterText({
+                                text: localizacaoGeografica,
+                            }),
+                            errorMessage:
+                                "Não foi possível inserir um valor para a localização geográfica",
+                        });
+                    },
+                    euDigitoUmaHabilidadeRacialNoInputField: function (habilidadeRacial) {
+                        return this.waitFor({
+                            id: ID_INPUT_HABILIDADE_RACIAL,
+                            viewName: NOME_VIEW,
+                            actions: new EnterText({
+                                text: habilidadeRacial,
+                            }),
+                            errorMessage:
+                                "Não foi possível inserir um valor para a habilidade racial",
+                        });
+                    },
+                    euSelecionoCondicaoExinta: function () {
+                        return this.waitFor({
+                            id: ID_RADIO_BUTTON_EXTINTA,
+                            viewName: NOME_VIEW,
+                            actions: new Press(),
+                            errorMessage: "Não foi possível selecionar o box 'Vivo'",
+                        });
+                    },
+                    euSelecionoCondicaoNaoExtinta: function () {
+                        return this.waitFor({
+                            id: ID_RADIO_BUTTON_NAO_EXTINTA,
+                            viewName: NOME_VIEW,
+                            actions: new Press(),
+                            errorMessage: "Não foi possível selecionar o box 'Morto'",
+                        });
+                    },
+                    euPressionoOBotaoEditar: function () {
+                        return this.waitFor({
+                            controlType: "sap.m.Button",
+                            matchers: new PropertyStrictEquals({
+                                name: "type",
+                                value: "Accept",
+                            }),
+                            actions: new Press(),
+                            success: function () {
+                                Opa5.assert.ok(true, "O botão editar foi pressionado");
+                            },
+                            errorMessage: "Não foi possível encontrar o botao editar",
+                        });
+                    },
+                    euPressionoOBotaoCancelar: function () {
+                        return this.waitFor({
+                            controlType: "sap.m.Button",
+                            matchers: new PropertyStrictEquals({
+                                name: "type",
+                                value: "Reject",
+                            }),
+                            actions: new Press(),
+                            success: function () {
+                                Opa5.assert.ok(true, "O botão cancelar foi pressionado");
+                            },
+                            errorMessage: "Não foi possível encontrar o botao cancelar",
+                        });
+                    },
+                    euPressionoBotaoFechar: function () {
+                        return this.waitFor({
+                            searchOpenDialogs: true,
+                            controlType: "sap.m.Button",
+                            actions: new Press(),
+                            success: function () {
+                                Opa5.assert.ok(true, "O botão 'Fechar' foi pressionado");
+                            },
+                            errorMessage: "Não foi possível encontrar o botao 'Fechar'",
+                        });
+                    },
+                    euPressionoBotaoVoltar: function () {
+                        return this.waitFor({
+                            id: ID_PAGINA,
+                            viewName: NOME_VIEW,
+                            actions: new Press(),
+                            errorMessage:
+                                "Não foi possível encontrar o botão voltar na página",
+                        });
+                    },
+                },
+                assertions: {
+                    deveAparecerUmaMessageBoxDeErro: function () {
+                        return this.waitFor({
+                            searchOpenDialogs: true,
+                            controlType: "sap.m.Dialog",
+                            matchers: new PropertyStrictEquals({
+                                name: "title",
+                                value: "Erro ao criar raça",
+                            }),
+                            success: function () {
+                                Opa5.assert.ok(
+                                    true,
+                                    "Foi encontrada a MessageBox indicando um erro"
+                                );
+                            },
+                            errorMessage: "Não foi encontrada a MessageBox indicando um erro",
+                        });
+                    },
+                    deveAparecerUmaMessageBoxDeErroVindoDoServidor: function () {
+                        return this.waitFor({
+                            searchOpenDialogs: true,
+                            controlType: "sap.m.Dialog",
+                            matchers: new PropertyStrictEquals({
+                                name: "title",
+                                value: "Ocorreram um ou mais erros de validação",
+                            }),
+                            success: function () {
+                                Opa5.assert.ok(
+                                    true,
+                                    "Foi encontrada a MessageBox indicando um erro"
+                                );
+                            },
+                            errorMessage: "Não foi encontrada a MessageBox indicando um erro",
+                        });
+                    },
+                    aTelaHomeFoiCarregadaCorretamente: function () {
+                        return this.waitFor({
+                            viewName: NOME_VIEW_HOME,
+                            success: () =>
+                                Opa5.assert.ok(
+                                    true,
+                                    "A tela 'Home' foi carregada corretamente"
+                                ),
+                            errorMessage: "A tela 'Home' não foi carregada corretamente",
+                        });
+                    },
+                    aTelaDeEdicaoFoiCarregadaCorretamente: function (){
+                        return this.waitFor({
+                            controlType: "sap.m.Page",
+                            matchers: new I18NText({
+                                propertyName: "title",
+                                key: "TituloPaginaEditarRaca",
+                            }),
+                            success: function (pagina) {
+                                Opa5.assert.ok(pagina, "O título da página está correto.");
+                            },
+                            errorMessage:
+                                "Não foi encontrado título correspondente ou não foi possível navegar até a página",
+                        });
+                    },
+                    oBotaoEditarTemONomeCorreto: function (){
+                        return this.waitFor({
+                            controlType: "sap.m.Button",
+                            matchers: new I18NText({
+                                propertyName: "text",
+                                key: "BotaoEditar",
+                            }),
+                            success: function (botao) {
+                                Opa5.assert.ok(botao, "O texto do botao na página está correto.");
+                            },
+                            errorMessage:
+                                "Não foi encontrado texto do botao correspondente ou não foi possível encontrar o botão em si",
+                        });
+                    },
+                    osInputDeNomeDeveEstarPreenchido: function (nomeDaRaca){
+                        return this.waitFor({
+                            controlType: "sap.m.Input",
+                            matchers: new PropertyStrictEquals({
+                                name: "value",
+                                value: nomeDaRaca,
+                            }),
+                            success: function (input) {
+                                Opa5.assert.ok(input, `O input de nome esta preenchido com ${nomeDaRaca}.`);
+                            },
+                            errorMessage:
+                                `Não foi encontrado ${nomeDaRaca} no input ou não foi possível encontrar o input`,
+                        });
+                    },
+                },
+            },
+        });
+    }
+);

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/BaseController.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/BaseController.js
@@ -1,49 +1,53 @@
 sap.ui.define(
-  [
-    "sap/ui/core/mvc/Controller",
-    "sap/ui/core/routing/History",
-    "sap/ui/core/UIComponent",
-  ],
-  function (Controller, History, UIComponent) {
-    "use strict";
+    [
+        "sap/ui/core/mvc/Controller",
+        "sap/ui/core/routing/History",
+        "sap/ui/core/UIComponent",
+    ],
+    function (Controller, History, UIComponent) {
+        "use strict";
 
-    return Controller.extend(
-      "ui5.o_senhor_dos_aneis.controller.BaseController",
-      {
-        vincularRota: function (rota, aoCoincidirRota) {
-          var oRouter = sap.ui.core.UIComponent.getRouterFor(this);
-          var oRoute = oRouter.getRoute(rota);
-          if (oRoute) {
-            oRoute.attachPatternMatched(aoCoincidirRota, this);
-          }
-        },
+        return Controller.extend(
+            "ui5.o_senhor_dos_aneis.controller.BaseController",
+            {
+                vincularRota: function (rota, aoCoincidirRota) {
+                    var oRouter = sap.ui.core.UIComponent.getRouterFor(this);
+                    var oRoute = oRouter.getRoute(rota);
+                    if (oRoute) {
+                        oRoute.attachPatternMatched(aoCoincidirRota, this);
+                    }
+                },
 
-        getRouter: function () {
-          return UIComponent.getRouterFor(this);
-        },
+                getRouter: function () {
+                    return UIComponent.getRouterFor(this);
+                },
 
-        onNavBack: function () {
-          var historico, hashAnterior, hashAtual, hashNotFound;
+                onNavBack: function () {
+                    var historico, hashAnterior, hashAtual, hashNotFound;
 
-          historico = History.getInstance();
-          hashAnterior = historico.getPreviousHash();
-          hashAtual = historico._oHashChanger._oRouterHashChanger.hash;
-          hashNotFound = "notFound";
+                    historico = History.getInstance();
+                    hashAnterior = historico.getPreviousHash();
+                    hashAtual = historico._oHashChanger._oRouterHashChanger.hash;
+                    hashNotFound = "notFound";
 
-          if (
-            hashAnterior !== undefined &&
-            hashAnterior !== hashNotFound &&
-            hashAtual !== hashNotFound
-          ) {
-            window.history.go(-1);
-          } else {
-            this.getRouter().navTo("appHome", {});
-          }
-        },
-        onNavTo: function (rota, parametros) {
-          this.getRouter().navTo(rota, parametros);
-        },
-      }
-    );
-  }
+                    if (
+                        hashAnterior !== undefined &&
+                        hashAnterior !== hashNotFound &&
+                        hashAtual !== hashNotFound
+                    ) {
+                        window.history.go(-1);
+                    } else {
+                        this.getRouter().navTo("appHome", {});
+                    }
+                },
+                onNavTo: function (rota, parametros) {
+                    this.getRouter().navTo(rota, parametros);
+                },
+                obterTextoI18N: function (chave) {
+                    const oBundle = this.getView().getModel("i18n").getResourceBundle();
+                    return oBundle.getText(chave);
+                },
+            }
+        );
+    }
 );

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
@@ -1,281 +1,274 @@
 sap.ui.define(
-  [
-    "../controller/BaseController",
-    "ui5/o_senhor_dos_aneis/services/RacaService",
-    "sap/ui/model/json/JSONModel",
-    "sap/m/MessageBox",
-      "ui5/o_senhor_dos_aneis/model/formatter",
-  ],
-  function (BaseController, RacaService, JSONModel, MessageBox, formatter) {
-    "use strict";
-    const ID_INPUT_NOME = "inputNome",
-      ID_INPUT_LOCALIZACAO = "inputLocalizacaoGeografica",
-      ID_INPUT_HABILIDADE = "inputHabilidadeRacial",
-      ID_RADIO_BTN_EXTINTAOUNAO = "radioBtnExtintaOuNao";
-    return BaseController.extend(
-      "ui5.o_senhor_dos_aneis.controller.CriarRaca",
-      {
-          formatter: formatter,
+    [
+        "../controller/BaseController",
+        "ui5/o_senhor_dos_aneis/services/RacaService",
+        "sap/ui/model/json/JSONModel",
+        "sap/m/MessageBox",
+        "ui5/o_senhor_dos_aneis/model/formatter",
+    ],
+    function (BaseController, RacaService, JSONModel, MessageBox, formatter) {
+        "use strict";
+        const ID_INPUT_NOME = "inputNome",
+            ID_INPUT_LOCALIZACAO = "inputLocalizacaoGeografica",
+            ID_INPUT_HABILIDADE = "inputHabilidadeRacial",
+            ID_RADIO_BTN_EXTINTAOUNAO = "radioBtnExtintaOuNao";
+        return BaseController.extend(
+            "ui5.o_senhor_dos_aneis.controller.CriarRaca",
+            {
+                formatter: formatter,
 
-        onInit: function () {
-          const rotaCriacao = "criarRaca";
-          const rotaEdicao = "editarRaca";
-          this.vincularRota(rotaCriacao, this.aoCoincidirRotaCriar);
-          this.vincularRota(rotaEdicao, this.aoCoincidirRotaEditar);
-        },
+                onInit: function () {
+                    const rotaCriacao = "criarRaca";
+                    const rotaEdicao = "editarRaca";
+                    this.vincularRota(rotaCriacao, this.aoCoincidirRotaCriar);
+                    this.vincularRota(rotaEdicao, this.aoCoincidirRotaEditar);
+                },
 
-        aoCoincidirRotaCriar: function (oEvent) {
-          this.filtros = {};
-          this.raca = {};
-          this.errosDeValidacao = {};
-          this.modoEditar = false;
-          this._limparInputs();
-          this._atualizarTextoDaPáginaCriar();
-        },
+                aoCoincidirRotaCriar: function (oEvent) {
+                    this.filtros = {};
+                    this.raca = {};
+                    this.errosDeValidacao = {};
+                    this.modoEditar = false;
+                    this._limparInputs();
+                    this._atualizarTextoDaPáginaCriar();
+                },
 
-        aoCoincidirRotaEditar: function (oEvent) {
-          this.filtros = {};
-          this.raca = {};
-          this.errosDeValidacao = {};
-          this.modoEditar = true;
-          this._limparInputs();
-          this._carregarDadosDaRacaSelecionada(oEvent);
-          this._atualizarTextoDaPáginaEditar();
-        },
+                aoCoincidirRotaEditar: function (oEvent) {
+                    this.filtros = {};
+                    this.raca = {};
+                    this.errosDeValidacao = {};
+                    this.modoEditar = true;
+                    this._limparInputs();
+                    this._carregarDadosDaRacaSelecionada(oEvent);
+                    this._atualizarTextoDaPáginaEditar();
+                },
 
-        aoMudarNome: function (oEvent) {
-          this._aoMudarInput(oEvent, this._validarNome.bind(this));
-        },
+                aoMudarNome: function (oEvent) {
+                    this._aoMudarInput(oEvent, this._validarNome.bind(this));
+                },
 
-        aoCriarRaca: async function (oEvent) {
-          this._pegarValoresDaRacaNaTela();
-          const sucessoMessageBox = (mensagem, titulo) => {
-            console.log("Exibindo MessageBox:", mensagem); // Verifica se esta linha é executada
-            MessageBox.show(mensagem, {
-              icon: sap.m.MessageBox.Icon.SUCCESS,
-              title: titulo,
-              dependentOn: this.getView(),
-            });
-          };
-          if (!this.modoEditar) {
-            if (this._validarNovaRaca(this.raca)) {
-              try {
-                const racaCriada = await RacaService.adicionarRaca(this.raca);
-                const mensagemDeSucesso = "Raça adicionada com sucesso!";
-                const tituloDaMessageBox = "Sucesso";
-                sucessoMessageBox(mensagemDeSucesso, tituloDaMessageBox);
-                this._limparInputs();
-                const tempoParaVisualizarMensagem = 2000;
-                setTimeout(() => this.onNavBack(), tempoParaVisualizarMensagem);
-              } catch (erros) {
-                this._exibirErros(erros);
-              }
+                aoCriarRaca: async function (oEvent) {
+                    this._pegarValoresDaRacaNaTela();
+                    const sucessoMessageBox = (mensagem, titulo) => {
+                        MessageBox.show(mensagem, {
+                            icon: sap.m.MessageBox.Icon.SUCCESS,
+                            title: titulo,
+                            dependentOn: this.getView(),
+                        });
+                    };
+                    if (!this.modoEditar) {
+                        if (this._validarNovaRaca(this.raca)) {
+                            try {
+                                const racaCriada = await RacaService.adicionarRaca(this.raca);
+                                const mensagemDeSucesso = "Raça adicionada com sucesso!";
+                                const tituloDaMessageBox = "Sucesso";
+                                sucessoMessageBox(mensagemDeSucesso, tituloDaMessageBox);
+                                this._limparInputs();
+                                const tempoParaVisualizarMensagem = 2000;
+                                setTimeout(() => this.onNavBack(), tempoParaVisualizarMensagem);
+                            } catch (erros) {
+                                this._exibirErros(erros);
+                            }
+                        }
+                        return;
+                    }
+                    try {
+                        const racaEditada = await RacaService.editarRaca(this.raca);
+                        const mensagemDeSucesso = "Raça editada com sucesso!";
+                        const tituloDaMessageBox = "Sucesso";
+                        sucessoMessageBox(mensagemDeSucesso, tituloDaMessageBox);
+                        this._limparInputs();
+                        const tempoParaVisualizarMensagem = 2000;
+                        setTimeout(() => this.onNavBack(), tempoParaVisualizarMensagem);
+                    } catch (erros) {
+                        this._exibirErros(erros);
+                    }
+                },
+
+                onNavToListaDeRacas: function () {
+                    const rotaListaDeRacas = "listaDeRacas";
+                    this.onNavTo(rotaListaDeRacas);
+                },
+
+                _carregarDadosDaRacaSelecionada: async function (oEvent) {
+                    if (oEvent.getParameter("arguments").id) {
+                        try {
+                            const idRaca = oEvent.getParameter("arguments").id;
+                            const raca = await RacaService.obterRaca(idRaca);
+                            const modelo = new JSONModel(raca);
+                            const modeloRaca = "raca";
+
+                            this.getView().setModel(modelo, modeloRaca);
+                        } catch (erros) {
+                            this._exibirErros(erros);
+                        }
+                    }
+                },
+
+                _atualizarTextoDaPáginaCriar: function () {
+                    this._atualizarTituloDaPaginaCriar();
+                    this._atualizarLabelDoBotaoAdicionar();
+                },
+
+                _atualizarTextoDaPáginaEditar: function () {
+                    this._atualizarTituloDaPaginaEditar();
+                    this._atualizarLabelDoBotaoEditar();
+                },
+
+                _atualizarTituloDaPaginaCriar: function () {
+                    const idPaginaCriacao = "paginaCriarRaca";
+                    const chaveI18N = "TituloPaginaCriarRaca";
+                    this.byId(idPaginaCriacao).setTitle(this.obterTextoI18N(chaveI18N));
+                },
+
+                _atualizarTituloDaPaginaEditar: function () {
+                    const idPaginaCriacao = "paginaCriarRaca";
+                    const chaveI18N = "TituloPaginaEditarRaca";
+                    this.byId(idPaginaCriacao).setTitle(this.obterTextoI18N(chaveI18N));
+                },
+
+                _atualizarLabelDoBotaoAdicionar: function () {
+                    const idBotaoAdicionar = "criarRacaBtn";
+                    const chaveI18N = "BotaoAdicionar";
+                    this.byId(idBotaoAdicionar).setText(this.obterTextoI18N(chaveI18N));
+                },
+
+                _atualizarLabelDoBotaoEditar: function () {
+                    const idBotaoAdicionar = "criarRacaBtn";
+                    const chaveI18N = "BotaoEditar";
+                    this.byId(idBotaoAdicionar).setText(this.obterTextoI18N(chaveI18N));
+                },
+
+                _aoMudarInput: function (oEvent, funcaoDeValidacao) {
+                    const objeto = oEvent.getSource();
+                    const nomeInserido = objeto.getValue();
+                    let valueState = funcaoDeValidacao(nomeInserido)
+                        ? "Success"
+                        : "Error";
+                    objeto.setValueState(valueState);
+                },
+
+                _validarNovaRaca: function (raca) {
+                    let racaValida = false;
+                    const nomeInseridoInput = this._validarNome(raca.nome);
+                    if (nomeInseridoInput) {
+                        racaValida = true;
+                        return racaValida;
+                    }
+                    this._exibirErros(this.errosDeValidacao);
+                    return racaValida;
+                },
+
+                _validarNome: function (nomeInserido) {
+                    let nomeValido = false;
+                    const contemCaracteresEspeciais =
+                        this._verificarCaracteresEspeciais(nomeInserido);
+                    const tamanhoDaString = this._verificarTamanhoString(nomeInserido);
+                    if (!contemCaracteresEspeciais && tamanhoDaString) {
+                        nomeValido = true;
+                        return nomeValido;
+                    }
+                    return nomeValido;
+                },
+
+                _verificarCaracteresEspeciais: function (str) {
+                    const regex = /[^a-zA-Z]/;
+                    if (regex.test(str)) {
+                        const mensagemDeErro =
+                            "O nome não pode conter números, espaços ou caracteres especiais";
+                        this.errosDeValidacao.caracteresEspeciais = mensagemDeErro;
+                        return regex.test(str);
+                    }
+                    delete this.errosDeValidacao.caracteresEspeciais;
+                    return regex.test(str);
+                },
+
+                _verificarTamanhoString: function (str) {
+                    const tamanhoMinimo = 3;
+                    if (str.length < tamanhoMinimo) {
+                        const mensagemDeErro = "O nome precisa ter pelo menos 3 caracteres";
+                        this.errosDeValidacao.tamanhoDaString = mensagemDeErro;
+                        return str.length >= tamanhoMinimo;
+                    }
+                    delete this.errosDeValidacao.tamanhoDaString;
+                    return str.length >= tamanhoMinimo;
+                },
+
+                _exibirErros: function (erros) {
+                    const espacoEntreErros = ".\n";
+                    if (erros.status) {
+                        let mensagemDeErro = Object.values(erros.extensions.erros).join(
+                            espacoEntreErros
+                        );
+                        const tituloErro = erros.title;
+                        const detalhesDoErro = erros.detail;
+                        MessageBox.error(mensagemDeErro, {
+                            title: tituloErro,
+                            details: detalhesDoErro,
+                            contentWidth: "400px",
+                            dependentOn: this.getView(),
+                        });
+                    }
+                    if (
+                        this.errosDeValidacao.caracteresEspeciais ||
+                        this.errosDeValidacao.tamanhoDaString ||
+                        this.errosDeValidacao.idadeMinima ||
+                        this.errosDeValidacao.alturaMinima
+                    ) {
+                        let mensagemDeErro = Object.values(this.errosDeValidacao).join(
+                            espacoEntreErros
+                        );
+                        const tituloErro = "Erro ao criar raça";
+                        const detailsErro =
+                            "Corrija os campos acima para prosseguir com a criação da raça";
+                        MessageBox.error(mensagemDeErro, {
+                            title: tituloErro,
+                            details: detailsErro,
+                            contentWidth: "300px",
+                            dependentOn: this.getView(),
+                        });
+                    }
+                },
+
+                _pegarValoresDaRacaNaTela: function () {
+                    const modelo = this.getView().getModel("raca");
+
+                    const dadosDoModelo = modelo.getData();
+                    const condicaoExtinta = 0;
+                    const condicaoEstaExtintaNoModelo =
+                        this.byId(ID_RADIO_BTN_EXTINTAOUNAO).getSelectedIndex() ==
+                        condicaoExtinta
+                            ? true
+                            : false;
+
+                    this.raca = {
+                        id: dadosDoModelo.id,
+                        nome: dadosDoModelo.nome,
+                        localizacaoGeografica: dadosDoModelo.localizacaoGeografica,
+                        habilidadeRacial: dadosDoModelo.habilidadeRacial,
+                        estaExtinta: condicaoEstaExtintaNoModelo,
+                    };
+                },
+
+                _limparInputs: function () {
+                    const stringVazia = "";
+                    const condicaoInicial = 0;
+                    const valueStatePadrao = "None";
+
+                    const modeloRaca = "raca";
+                    const modelo = new JSONModel({
+                        nome: stringVazia,
+                        localizacaoGeografica: stringVazia,
+                        habilidadeRacial: stringVazia,
+                    });
+                    this.getView().setModel(modelo, modeloRaca);
+
+                    this.byId(ID_INPUT_NOME).setValueState(valueStatePadrao);
+                    this.byId(ID_RADIO_BTN_EXTINTAOUNAO).setSelectedIndex(
+                        condicaoInicial
+                    );
+                },
             }
-          } else {
-            if (this._validarNovaRaca(this.raca)) {
-              try {
-                const racaEditada = await RacaService.editarRaca(this.raca);
-                const mensagemDeSucesso = "Raça editada com sucesso!";
-                const tituloDaMessageBox = "Sucesso";
-                sucessoMessageBox(mensagemDeSucesso, tituloDaMessageBox);
-                this._limparInputs();
-                const tempoParaVisualizarMensagem = 2000;
-                setTimeout(() => this.onNavBack(), tempoParaVisualizarMensagem);
-              } catch (erros) {
-                this._exibirErros(erros);
-              }
-            }
-          }
-        },
-
-        onNavToListaDeRacas: function () {
-          const rotaListaDeRacas = "listaDeRacas";
-          this.onNavTo(rotaListaDeRacas);
-        },
-
-        _carregarDadosDaRacaSelecionada: async function (oEvent) {
-          if (oEvent.getParameter("arguments").id) {
-            try {
-              const idRaca = oEvent.getParameter("arguments").id;
-              const raca = await RacaService.obterRaca(idRaca);
-              const modelo = new JSONModel(raca);
-              const modeloRaca = "raca";
-
-              this.getView().setModel(modelo, modeloRaca);
-            } catch (erros) {
-              this._exibirErros(erros);
-            }
-          }
-        },
-
-        _atualizarTextoDaPáginaCriar: function () {
-          this._atualizarTituloDaPaginaCriar();
-          this._atualizarLabelDoBotaoAdicionar();
-        },
-
-        _atualizarTextoDaPáginaEditar: function () {
-          this._atualizarTituloDaPaginaEditar();
-          this._atualizarLabelDoBotaoEditar();
-        },
-
-        _atualizarTituloDaPaginaCriar: function () {
-          const idPaginaCriacao = "paginaCriarRaca";
-          const oBundle = this.getView().getModel("i18n").getResourceBundle();
-          const novoTitulo = oBundle.getText("TituloPaginaCriarRaca");
-          this.byId(idPaginaCriacao).setTitle(novoTitulo);
-        },
-
-        _atualizarTituloDaPaginaEditar: function () {
-          const idPaginaCriacao = "paginaCriarRaca";
-          const oBundle = this.getView().getModel("i18n").getResourceBundle();
-          const novoTitulo = oBundle.getText("TituloPaginaEditarRaca");
-          this.byId(idPaginaCriacao).setTitle(novoTitulo);
-        },
-
-        _atualizarLabelDoBotaoAdicionar: function () {
-          const idBotaoAdicionar = "criarRacaBtn";
-          const oBundle = this.getView().getModel("i18n").getResourceBundle();
-          const novoLabel = oBundle.getText("BotaoAdicionar");
-          this.byId(idBotaoAdicionar).setText(novoLabel);
-        },
-
-        _atualizarLabelDoBotaoEditar: function () {
-          const idBotaoAdicionar = "criarRacaBtn";
-          const oBundle = this.getView().getModel("i18n").getResourceBundle();
-          const novoLabel = oBundle.getText("BotaoEditar");
-          this.byId(idBotaoAdicionar).setText(novoLabel);
-        },
-
-        _aoMudarInput: function (oEvent, funcaoDeValidacao) {
-          const objeto = oEvent.getSource();
-          const nomeInserido = objeto.getValue();
-          let valueState = funcaoDeValidacao(nomeInserido)
-            ? "Success"
-            : "Error";
-          objeto.setValueState(valueState);
-        },
-
-        _validarNovaRaca: function (raca) {
-          let racaValida = false;
-          const nomeInseridoInput = this._validarNome(raca.nome);
-          if (nomeInseridoInput) {
-            racaValida = true;
-            return racaValida;
-          }
-          this._exibirErros(this.errosDeValidacao);
-          return racaValida;
-        },
-
-        _validarNome: function (nomeInserido) {
-          let nomeValido = false;
-          const contemCaracteresEspeciais =
-            this._verificarCaracteresEspeciais(nomeInserido);
-          const tamanhoDaString = this._verificarTamanhoString(nomeInserido);
-          if (!contemCaracteresEspeciais && tamanhoDaString) {
-            nomeValido = true;
-            return nomeValido;
-          }
-          return nomeValido;
-        },
-
-        _verificarCaracteresEspeciais: function (str) {
-          const regex = /[^a-zA-Z]/;
-          if (regex.test(str)) {
-            const mensagemDeErro =
-              "O nome não pode conter números, espaços ou caracteres especiais";
-            this.errosDeValidacao.caracteresEspeciais = mensagemDeErro;
-            return regex.test(str);
-          }
-          delete this.errosDeValidacao.caracteresEspeciais;
-          return regex.test(str);
-        },
-
-        _verificarTamanhoString: function (str) {
-          const tamanhoMinimo = 3;
-          if (str.length < tamanhoMinimo) {
-            const mensagemDeErro = "O nome precisa ter pelo menos 3 caracteres";
-            this.errosDeValidacao.tamanhoDaString = mensagemDeErro;
-            return str.length >= tamanhoMinimo;
-          }
-          delete this.errosDeValidacao.tamanhoDaString;
-          return str.length >= tamanhoMinimo;
-        },
-
-        _exibirErros: function (erros) {
-          const espacoEntreErros = ".\n";
-          if (erros.status) {
-            let mensagemDeErro = Object.values(erros.extensions.erros).join(
-              espacoEntreErros
-            );
-            const tituloErro = erros.title;
-            const detalhesDoErro = erros.detail;
-            MessageBox.error(mensagemDeErro, {
-              title: tituloErro,
-              details: detalhesDoErro,
-              contentWidth: "400px",
-              dependentOn: this.getView(),
-            });
-          }
-          if (
-            this.errosDeValidacao.caracteresEspeciais ||
-            this.errosDeValidacao.tamanhoDaString ||
-            this.errosDeValidacao.idadeMinima ||
-            this.errosDeValidacao.alturaMinima
-          ) {
-            let mensagemDeErro = Object.values(this.errosDeValidacao).join(
-              espacoEntreErros
-            );
-            const tituloErro = "Erro ao criar raça";
-            const detailsErro =
-              "Corrija os campos acima para prosseguir com a criação da raça";
-            MessageBox.error(mensagemDeErro, {
-              title: tituloErro,
-              details: detailsErro,
-              contentWidth: "300px",
-              dependentOn: this.getView(),
-            });
-          }
-        },
-
-        _pegarValoresDaRacaNaTela: function () {
-          const modelo = this.getView().getModel("raca");
-
-          const dadosDoModelo = modelo.getData();
-          const condicaoExtinta = 0;
-          const condicaoEstaExtintaNoModelo =
-            this.byId(ID_RADIO_BTN_EXTINTAOUNAO).getSelectedIndex() ==
-            condicaoExtinta
-              ? true
-              : false;
-
-          this.raca = {
-            id: dadosDoModelo.id,
-            nome: dadosDoModelo.nome,
-            localizacaoGeografica: dadosDoModelo.localizacaoGeografica,
-            habilidadeRacial: dadosDoModelo.habilidadeRacial,
-            estaExtinta: condicaoEstaExtintaNoModelo,
-          };
-        },
-
-        _limparInputs: function () {
-          const stringVazia = "";
-          const condicaoInicial = 0;
-          const valueStatePadrao = "None";
-
-          const modeloRaca = "raca";
-          const modelo = new JSONModel({
-            nome: stringVazia,
-            localizacaoGeografica: stringVazia,
-            habilidadeRacial: stringVazia,
-          });
-          this.getView().setModel(modelo, modeloRaca);
-
-          this.byId(ID_INPUT_NOME).setValueState(valueStatePadrao);
-          this.byId(ID_RADIO_BTN_EXTINTAOUNAO).setSelectedIndex(
-            condicaoInicial
-          );
-        },
-      }
-    );
-  }
+        );
+    }
 );

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
@@ -4,8 +4,9 @@ sap.ui.define(
     "ui5/o_senhor_dos_aneis/services/RacaService",
     "sap/ui/model/json/JSONModel",
     "sap/m/MessageBox",
+      "ui5/o_senhor_dos_aneis/model/formatter",
   ],
-  function (BaseController, RacaService, JSONModel, MessageBox) {
+  function (BaseController, RacaService, JSONModel, MessageBox, formatter) {
     "use strict";
     const ID_INPUT_NOME = "inputNome",
       ID_INPUT_LOCALIZACAO = "inputLocalizacaoGeografica",
@@ -14,6 +15,8 @@ sap.ui.define(
     return BaseController.extend(
       "ui5.o_senhor_dos_aneis.controller.CriarRaca",
       {
+          formatter: formatter,
+
         onInit: function () {
           const rotaCriacao = "criarRaca";
           const rotaEdicao = "editarRaca";

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
@@ -2,9 +2,10 @@ sap.ui.define(
   [
     "../controller/BaseController",
     "ui5/o_senhor_dos_aneis/services/RacaService",
+    "sap/ui/model/json/JSONModel",
     "sap/m/MessageBox",
   ],
-  function (BaseController, RacaService, MessageBox) {
+  function (BaseController, RacaService, JSONModel, MessageBox) {
     "use strict";
     const ID_INPUT_NOME = "inputNome",
       ID_INPUT_LOCALIZACAO = "inputLocalizacaoGeografica",
@@ -14,15 +15,18 @@ sap.ui.define(
       "ui5.o_senhor_dos_aneis.controller.CriarRaca",
       {
         onInit: function () {
-          const rota = "criarRaca";
-          this.vincularRota(rota, this.aoCoincidirRota);
+          const rotaCriacao = "criarRaca";
+          const rotaEdicao = "editarRaca";
+          this.vincularRota(rotaCriacao, this.aoCoincidirRota);
+          this.vincularRota(rotaEdicao, this.aoCoincidirRota);
         },
 
-        aoCoincidirRota: function () {
+        aoCoincidirRota: function (oEvent) {
           this.filtros = {};
           this.raca = {};
           this.errosDeValidacao = {};
           this._limparInputs();
+          this._carregarModeloDaRaca(oEvent);
         },
 
         aoMudarNome: function (oEvent) {
@@ -54,6 +58,25 @@ sap.ui.define(
           const rotaListaDeRacas = "listaDeRacas";
           this.onNavTo(rotaListaDeRacas);
         },
+
+        _carregarModeloDaRaca: async function (oEvent) {
+          if (oEvent.getParameter("arguments").id) {
+            try {
+              console.log(this.getView().getModel());
+              const idRaca = oEvent.getParameter("arguments").id;
+              const raca = await RacaService.obterRaca(idRaca);
+              console.log(oEvent.getParameter("arguments").id);
+              const modelo = new JSONModel(raca);
+              const modeloRaca = "raca";
+
+              this.getView().setModel(modelo, modeloRaca);
+            } catch (erros) {
+              console.log("Não foi possível obter a raça");
+            }
+          }
+        },
+
+        _carregarDadosDaRacaNaTela: function () {},
 
         _aoMudarInput: function (oEvent, funcaoDeValidacao) {
           const objeto = oEvent.getSource();

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
@@ -17,16 +17,27 @@ sap.ui.define(
         onInit: function () {
           const rotaCriacao = "criarRaca";
           const rotaEdicao = "editarRaca";
-          this.vincularRota(rotaCriacao, this.aoCoincidirRota);
-          this.vincularRota(rotaEdicao, this.aoCoincidirRota);
+          this.vincularRota(rotaCriacao, this.aoCoincidirRotaCriar);
+          this.vincularRota(rotaEdicao, this.aoCoincidirRotaEditar);
         },
 
-        aoCoincidirRota: function (oEvent) {
+        aoCoincidirRotaCriar: function (oEvent) {
           this.filtros = {};
           this.raca = {};
           this.errosDeValidacao = {};
+          this.modoEditar = false;
           this._limparInputs();
-          this._carregarModeloDaRaca(oEvent);
+          this._atualizarTextoDaPáginaCriar();
+        },
+
+        aoCoincidirRotaEditar: function (oEvent) {
+          this.filtros = {};
+          this.raca = {};
+          this.errosDeValidacao = {};
+          this.modoEditar = true;
+          this._limparInputs();
+          this._carregarDadosDaRacaSelecionada(oEvent);
+          this._atualizarTextoDaPáginaEditar();
         },
 
         aoMudarNome: function (oEvent) {
@@ -35,21 +46,41 @@ sap.ui.define(
 
         aoCriarRaca: async function (oEvent) {
           this._pegarValoresDaRacaNaTela();
-
-          if (this._validarNovaRaca(this.raca)) {
-            try {
-              const racaCriada = await RacaService.adicionarRaca(this.raca);
-              const mensagemDeSucesso = "Raça adicionada com sucesso!";
-              MessageBox.show(mensagemDeSucesso, {
-                icon: sap.m.MessageBox.Icon.SUCCESS,
-                title: "Sucesso",
-                dependentOn: this.getView(),
-              });
-              this._limparInputs();
-              const tempoParaVisualizarMensagem = 2000;
-              setTimeout(() => this.onNavBack(), tempoParaVisualizarMensagem);
-            } catch (erros) {
-              this._exibirErros(erros);
+          const sucessoMessageBox = (mensagem, titulo) => {
+            console.log("Exibindo MessageBox:", mensagem); // Verifica se esta linha é executada
+            MessageBox.show(mensagem, {
+              icon: sap.m.MessageBox.Icon.SUCCESS,
+              title: titulo,
+              dependentOn: this.getView(),
+            });
+          };
+          if (!this.modoEditar) {
+            if (this._validarNovaRaca(this.raca)) {
+              try {
+                const racaCriada = await RacaService.adicionarRaca(this.raca);
+                const mensagemDeSucesso = "Raça adicionada com sucesso!";
+                const tituloDaMessageBox = "Sucesso";
+                sucessoMessageBox(mensagemDeSucesso, tituloDaMessageBox);
+                this._limparInputs();
+                const tempoParaVisualizarMensagem = 2000;
+                setTimeout(() => this.onNavBack(), tempoParaVisualizarMensagem);
+              } catch (erros) {
+                this._exibirErros(erros);
+              }
+            }
+          } else {
+            if (this._validarNovaRaca(this.raca)) {
+              try {
+                const racaEditada = await RacaService.editarRaca(this.raca);
+                const mensagemDeSucesso = "Raça editada com sucesso!";
+                const tituloDaMessageBox = "Sucesso";
+                sucessoMessageBox(mensagemDeSucesso, tituloDaMessageBox);
+                this._limparInputs();
+                const tempoParaVisualizarMensagem = 2000;
+                setTimeout(() => this.onNavBack(), tempoParaVisualizarMensagem);
+              } catch (erros) {
+                this._exibirErros(erros);
+              }
             }
           }
         },
@@ -59,24 +90,58 @@ sap.ui.define(
           this.onNavTo(rotaListaDeRacas);
         },
 
-        _carregarModeloDaRaca: async function (oEvent) {
+        _carregarDadosDaRacaSelecionada: async function (oEvent) {
           if (oEvent.getParameter("arguments").id) {
             try {
-              console.log(this.getView().getModel());
               const idRaca = oEvent.getParameter("arguments").id;
               const raca = await RacaService.obterRaca(idRaca);
-              console.log(oEvent.getParameter("arguments").id);
               const modelo = new JSONModel(raca);
               const modeloRaca = "raca";
 
               this.getView().setModel(modelo, modeloRaca);
             } catch (erros) {
-              console.log("Não foi possível obter a raça");
+              this._exibirErros(erros);
             }
           }
         },
 
-        _carregarDadosDaRacaNaTela: function () {},
+        _atualizarTextoDaPáginaCriar: function () {
+          this._atualizarTituloDaPaginaCriar();
+          this._atualizarLabelDoBotaoAdicionar();
+        },
+
+        _atualizarTextoDaPáginaEditar: function () {
+          this._atualizarTituloDaPaginaEditar();
+          this._atualizarLabelDoBotaoEditar();
+        },
+
+        _atualizarTituloDaPaginaCriar: function () {
+          const idPaginaCriacao = "paginaCriarRaca";
+          const oBundle = this.getView().getModel("i18n").getResourceBundle();
+          const novoTitulo = oBundle.getText("TituloPaginaCriarRaca");
+          this.byId(idPaginaCriacao).setTitle(novoTitulo);
+        },
+
+        _atualizarTituloDaPaginaEditar: function () {
+          const idPaginaCriacao = "paginaCriarRaca";
+          const oBundle = this.getView().getModel("i18n").getResourceBundle();
+          const novoTitulo = oBundle.getText("TituloPaginaEditarRaca");
+          this.byId(idPaginaCriacao).setTitle(novoTitulo);
+        },
+
+        _atualizarLabelDoBotaoAdicionar: function () {
+          const idBotaoAdicionar = "criarRacaBtn";
+          const oBundle = this.getView().getModel("i18n").getResourceBundle();
+          const novoLabel = oBundle.getText("BotaoAdicionar");
+          this.byId(idBotaoAdicionar).setText(novoLabel);
+        },
+
+        _atualizarLabelDoBotaoEditar: function () {
+          const idBotaoAdicionar = "criarRacaBtn";
+          const oBundle = this.getView().getModel("i18n").getResourceBundle();
+          const novoLabel = oBundle.getText("BotaoEditar");
+          this.byId(idBotaoAdicionar).setText(novoLabel);
+        },
 
         _aoMudarInput: function (oEvent, funcaoDeValidacao) {
           const objeto = oEvent.getSource();
@@ -87,9 +152,9 @@ sap.ui.define(
           objeto.setValueState(valueState);
         },
 
-        _validarNovaRaca: function (personagem) {
+        _validarNovaRaca: function (raca) {
           let racaValida = false;
-          const nomeInseridoInput = this._validarNome(personagem.nome);
+          const nomeInseridoInput = this._validarNome(raca.nome);
           if (nomeInseridoInput) {
             racaValida = true;
             return racaValida;
@@ -170,18 +235,23 @@ sap.ui.define(
         },
 
         _pegarValoresDaRacaNaTela: function () {
-          this.raca.nome = this.byId(ID_INPUT_NOME).getValue();
-          this.raca.localizacaoGeografica =
-            this.byId(ID_INPUT_LOCALIZACAO).getValue();
-          this.raca.habilidadeRacial =
-            this.byId(ID_INPUT_HABILIDADE).getValue();
+          const modelo = this.getView().getModel("raca");
 
+          const dadosDoModelo = modelo.getData();
           const condicaoExtinta = 0;
-          this.raca.estaExtinta =
+          const condicaoEstaExtintaNoModelo =
             this.byId(ID_RADIO_BTN_EXTINTAOUNAO).getSelectedIndex() ==
             condicaoExtinta
               ? true
               : false;
+
+          this.raca = {
+            id: dadosDoModelo.id,
+            nome: dadosDoModelo.nome,
+            localizacaoGeografica: dadosDoModelo.localizacaoGeografica,
+            habilidadeRacial: dadosDoModelo.habilidadeRacial,
+            estaExtinta: condicaoEstaExtintaNoModelo,
+          };
         },
 
         _limparInputs: function () {
@@ -189,15 +259,15 @@ sap.ui.define(
           const condicaoInicial = 0;
           const valueStatePadrao = "None";
 
-          this.byId(ID_INPUT_NOME).setValue(stringVazia);
+          const modeloRaca = "raca";
+          const modelo = new JSONModel({
+            nome: stringVazia,
+            localizacaoGeografica: stringVazia,
+            habilidadeRacial: stringVazia,
+          });
+          this.getView().setModel(modelo, modeloRaca);
+
           this.byId(ID_INPUT_NOME).setValueState(valueStatePadrao);
-
-          this.byId(ID_INPUT_HABILIDADE).setValue(stringVazia);
-          this.byId(ID_INPUT_HABILIDADE).setValueState(valueStatePadrao);
-
-          this.byId(ID_INPUT_LOCALIZACAO).setValue(stringVazia);
-          this.byId(ID_INPUT_LOCALIZACAO).setValueState(valueStatePadrao);
-
           this.byId(ID_RADIO_BTN_EXTINTAOUNAO).setSelectedIndex(
             condicaoInicial
           );

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/DetalhesRaca.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/DetalhesRaca.controller.js
@@ -3,11 +3,10 @@ sap.ui.define(
     "../controller/BaseController",
     "ui5/o_senhor_dos_aneis/services/RacaService",
     "sap/ui/model/json/JSONModel",
-    "sap/m/MessageBox",
     "ui5/o_senhor_dos_aneis/model/formatter",
   ],
 
-  function (BaseController, RacaService, JSONModel, MessageBox, formatter) {
+  function (BaseController, RacaService, JSONModel, formatter) {
     "use strict";
     return BaseController.extend(
       "ui5.o_senhor_dos_aneis.controller.DetalhesRaca",
@@ -19,9 +18,15 @@ sap.ui.define(
           this.vincularRota(rota, this.aoCoincidirRota);
         },
         aoCoincidirRota: function (oEvent) {
-          this._carregarModeloDoPersonagem(oEvent);
+          this._carregarModeloDaRaca(oEvent);
         },
-        _carregarModeloDoPersonagem: async function (oEvent) {
+        onNavToEditarRaca: function () {
+          const modelo = "raca",
+            rotaEditarRaca = "editarRaca",
+            idRacaSelecionada = this.getView().getModel(modelo).getData().id;
+          this.onNavTo(rotaEditarRaca, { id: idRacaSelecionada });
+        },
+        _carregarModeloDaRaca: async function (oEvent) {
           try {
             const idRaca = oEvent.getParameter("arguments").id;
             const raca = await RacaService.obterRaca(idRaca);

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/ListaRacas.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/ListaRacas.controller.js
@@ -82,7 +82,8 @@ sap.ui.define(
         },
         onNavToCriarRaca: function () {
           const rotaCriarRaca = "criarRaca";
-          this.onNavTo(rotaCriarRaca);
+          const parametros = "criarNovaRaca";
+          this.onNavTo(rotaCriarRaca, parametros);
         },
       }
     );

--- a/Cod3rsGrowth.Web/wwwroot/webapp/manifest.json
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/manifest.json
@@ -80,8 +80,13 @@
           "target": "criarPersonagem"
         },
         {
-          "pattern": "raca/criarRaca",
+          "pattern": "raca/criarRaca/",
           "name": "criarRaca",
+          "target": "criarRaca"
+        },
+        {
+          "pattern": "raca/editarRaca/{id}",
+          "name": "editarRaca",
           "target": "criarRaca"
         },
         {

--- a/Cod3rsGrowth.Web/wwwroot/webapp/model/formatter.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/model/formatter.js
@@ -99,5 +99,11 @@ sap.ui.define([], () => {
       }
       return "Success";
     },
+    formatarCondicaoExtintaInicial(extinto){
+      if(extinto){
+        return 0;
+      }
+      return 1;
+    }
   };
 });

--- a/Cod3rsGrowth.Web/wwwroot/webapp/services/RacaService.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/services/RacaService.js
@@ -26,7 +26,7 @@ sap.ui.define([], function () {
 
     obterRaca: function (idRaca) {
       const urlRaca = new URL(`${URL_OBTER_RACA}/${idRaca}`);
-
+      console.log(urlRaca);
       return fetch(urlRaca.href)
         .then((response) => {
           if (!response.ok) {

--- a/Cod3rsGrowth.Web/wwwroot/webapp/services/RacaService.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/services/RacaService.js
@@ -4,6 +4,7 @@ sap.ui.define([], function () {
   const URL_TODAS_AS_RACAS = "https://localhost:7244/api/Raca/racas";
   const URL_OBTER_RACA = "https://localhost:7244/api/Raca/raca";
   const URL_POST_RACA = "https://localhost:7244/api/Raca/raca";
+  const URL_PUT_RACA = "https://localhost:7244/api/Raca/raca";
 
   return {
     obterTodos: async function (filtros) {
@@ -26,7 +27,6 @@ sap.ui.define([], function () {
 
     obterRaca: function (idRaca) {
       const urlRaca = new URL(`${URL_OBTER_RACA}/${idRaca}`);
-      console.log(urlRaca);
       return fetch(urlRaca.href)
         .then((response) => {
           if (!response.ok) {
@@ -51,8 +51,33 @@ sap.ui.define([], function () {
           },
         });
         if (!response.ok) {
-          const erro = await response.json();
-          throw erro;
+          throw await response.json();
+        }
+        if (response.status == 200) {
+          return;
+        }
+        return await response.json();
+      } catch (erro) {
+        throw erro;
+      }
+    },
+
+    editarRaca: async function (raca) {
+      let urlRacas = new URL(URL_PUT_RACA);
+
+      try {
+        const response = await fetch(urlRacas.href, {
+          method: "PUT",
+          body: JSON.stringify(raca),
+          headers: {
+            "Content-type": "application/json; charset=UTF-8",
+          },
+        });
+        if (!response.ok) {
+          throw await response.json();
+        }
+        if (response.status == 200) {
+          return;
         }
         return await response.json();
       } catch (erro) {

--- a/Cod3rsGrowth.Web/wwwroot/webapp/view/CriarRaca.view.xml
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/view/CriarRaca.view.xml
@@ -33,6 +33,7 @@
                         placeholder="{i18n>PlaceholderNome}"
                         change=".aoMudarNome"
                         width="15rem"
+                        value="{raca>/nome}"
                     />
                 </HBox>
 
@@ -48,6 +49,7 @@
                         placeholder="{i18n>PlaceholderLocalizacaoGeografica}"
                         change=".aoMudarLocalizacaoGeografica"
                         width="15rem"
+                        value="{raca>/localizacaoGeografica}"
                     />
                 </HBox>
                 <HBox alignItems="Center">
@@ -62,6 +64,7 @@
                         placeholder="{i18n>PlaceholHabilidadeRacial}"
                         change=".aoMudarHabilidadeRacial"
                         width="15rem"
+                        value="{raca>/habilidadeRacial}"
                     />
                 </HBox>
                 <HBox alignItems="Center">

--- a/Cod3rsGrowth.Web/wwwroot/webapp/view/CriarRaca.view.xml
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/view/CriarRaca.view.xml
@@ -79,6 +79,10 @@
                         columns="2"
                         valueState="None"
                         select="aoSelecionarCondicao"
+                        selectedIndex="{
+                                path: 'raca>/estaExtinta',
+                                formatter: '.formatter.formatarCondicaoExtintaInicial'
+                            }"
                     >
                         <RadioButton
                             id="radioBtnExtinta"

--- a/Cod3rsGrowth.Web/wwwroot/webapp/view/DetalhesRaca.view.xml
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/view/DetalhesRaca.view.xml
@@ -61,5 +61,31 @@
                 <ObjectMarker type="Favorite" />
             </markers>
         </ObjectHeader>
+        <footer>
+            <OverflowToolbar id="otbFooter">
+                <ToolbarSpacer />
+                <Button
+                    type="Emphasized"
+                    text="{i18n>BotaoEditar}"
+                    id="editarRacaBtn"
+                    press=".onNavToEditarRaca"
+                    class="sapUiTinyMarginEnd"
+                    width="100px"
+                >
+                    <layoutData>
+                        <OverflowToolbarLayoutData priority="High" />
+                    </layoutData>
+                </Button>
+                <Button
+                    type="Reject"
+                    text="{i18n>BotaoRemover}"
+                    width="100px"
+                >
+                    <layoutData>
+                        <OverflowToolbarLayoutData priority="Low" />
+                    </layoutData>
+                </Button>
+            </OverflowToolbar>
+        </footer>
     </Page>
 </mvc:View>


### PR DESCRIPTION
Modificado a view e a controller existentes da tela de criação para lidar tanto com a criação quanto com a edição dos registros pai.

Adicionada lógica na controller para verificar se os dados estão sendo fornecidos para a tela de forma a determinar se é uma operação de criação ou edição.

Se os dados estiverem presentes, preencha os campos do formulário com esses dados para permitir a edição. Caso contrário, a tela deve permanecer em modo de criação.

Certificado de que a lógica de envio de dados para a API esta adaptada para lidar com operações de edição, enviando os dados atualizados em vez de criar um novo registro.

Escrito testes OPA para verificar se a tela de edição está funcionando corretamente, tanto para operações de criação quanto de edição, e se os dados são enviados para a API conforme esperado.