### PR TITLE
Implementar na tela de detalhes a edicao dos registros filhos

### DIFF
--- a/Cod3rsGrowth.Web/Cod3rsGrowth.Web.csproj.user
+++ b/Cod3rsGrowth.Web/Cod3rsGrowth.Web.csproj.user
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Controller_SelectedScaffolderID>ApiControllerEmptyScaffolder</Controller_SelectedScaffolderID>
     <Controller_SelectedScaffolderCategoryPath>root/Common/Api</Controller_SelectedScaffolderCategoryPath>
-    <ActiveDebugProfile>https-Teste</ActiveDebugProfile>
+    <ActiveDebugProfile>https</ActiveDebugProfile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>

--- a/Cod3rsGrowth.Web/Cod3rsGrowth.Web.csproj.user
+++ b/Cod3rsGrowth.Web/Cod3rsGrowth.Web.csproj.user
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Controller_SelectedScaffolderID>ApiControllerEmptyScaffolder</Controller_SelectedScaffolderID>
     <Controller_SelectedScaffolderCategoryPath>root/Common/Api</Controller_SelectedScaffolderCategoryPath>
-    <ActiveDebugProfile>https</ActiveDebugProfile>
+    <ActiveDebugProfile>https-Teste</ActiveDebugProfile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>

--- a/Cod3rsGrowth.Web/wwwroot/i18n/i18n.properties
+++ b/Cod3rsGrowth.Web/wwwroot/i18n/i18n.properties
@@ -104,3 +104,5 @@ TituloPaginaDetalhesRaca = Race Details
 LabelId = Id
 BotaoEditar = Edit
 BotaoAdicionarPersonagem = Add Character
+BotaoEditarPersonagem = Edit
+BotaoRemoverPersonagem = Remove

--- a/Cod3rsGrowth.Web/wwwroot/i18n/i18n.properties
+++ b/Cod3rsGrowth.Web/wwwroot/i18n/i18n.properties
@@ -106,3 +106,7 @@ BotaoEditar = Edit
 BotaoAdicionarPersonagem = Add Character
 BotaoEditarPersonagem = Edit
 BotaoRemoverPersonagem = Remove
+
+#Modal Criacao de Personagem
+TituloModalCriarPersonagem = Create Character
+TituloModalEditarPersonagem = Edit Character

--- a/Cod3rsGrowth.Web/wwwroot/i18n/i18n_pt_br.properties
+++ b/Cod3rsGrowth.Web/wwwroot/i18n/i18n_pt_br.properties
@@ -108,3 +108,7 @@ BotaoEditar = Editar
 BotaoAdicionarPersonagem = Adicionar Personagem
 BotaoEditarPersonagem = Editar Personagem
 BotaoRemoverPersonagem = Remover Personagem
+
+#Modal Criacao de Personagem
+TituloModalCriarPersonagem = Criar Personagem
+TituloModalEditarPersonagem = Editar Personagem

--- a/Cod3rsGrowth.Web/wwwroot/i18n/i18n_pt_br.properties
+++ b/Cod3rsGrowth.Web/wwwroot/i18n/i18n_pt_br.properties
@@ -106,3 +106,5 @@ TituloPaginaDetalhesRaca = Detalhes da Raça
 LabelId = Id
 BotaoEditar = Editar
 BotaoAdicionarPersonagem = Adicionar Personagem
+BotaoEditarPersonagem = Editar Personagem
+BotaoRemoverPersonagem = Remover Personagem

--- a/Cod3rsGrowth.Web/wwwroot/test/integration/journeys/DetalhesRacaJourney.js
+++ b/Cod3rsGrowth.Web/wwwroot/test/integration/journeys/DetalhesRacaJourney.js
@@ -258,5 +258,83 @@ sap.ui.define(
         Then.iTeardownMyApp();
       }
     );
+    opaTest(
+      "Deve selecionar um personagem e aparecer o botao de editar personagem na tela",
+      function (Given, When, Then) {
+        //Arrangements
+        Given.iStartMyApp({
+          hash: "raca/2",
+        });
+
+        //Actions
+        When.naPaginaDeDetalhesDaRaca.euSelecionoUmPersonagemNaLista("Legolas");
+
+        //Assertions
+        Then.naPaginaDeDetalhesDaRaca.deveAparecerUmBotaoDeEditarPersonagemNaTela();
+
+        //Cleanup
+        Then.iTeardownMyApp();
+      }
+    );
+    opaTest(
+      "Deve pressionar o botao editar de um registro filho e carregar o modal de edição",
+      function (Given, When, Then) {
+        //Arrangements
+        Given.iStartMyApp({
+          hash: "raca/2",
+        });
+
+        //Actions
+        When.naPaginaDeDetalhesDaRaca
+          .euSelecionoUmPersonagemNaLista("Legolas")
+          .and.euPressionoOBotaoEditarPersonagem();
+
+        //Assertions
+        Then.naPaginaDeDetalhesDaRaca
+          .deveAparecerOModalDeEdicaoDePersonagem()
+          .and.oTituloDoModalDeveraSer()
+          .and.oInputDeNomeDeveraEstarPreenchido("Legolas")
+          .and.oTextoDoBotaoEditarDeveraSer();
+      }
+    );
+    opaTest(
+      "Deve pressionar o botao cancelar no modal e deve permancer na pagina de detalhes",
+      function (Given, When, Then) {
+        //Actions
+        When.naPaginaDeDetalhesDaRaca.euPressionoOBotaoCancelar();
+
+        //Assertions
+        Then.naPaginaDeDetalhesDaRaca.oTituloDaPaginaDetalhesDaRacaDeveraSer();
+
+        //Cleanup
+        Then.iTeardownMyApp();
+      }
+    );
+    opaTest(
+      "Deve tentar editar um personagem com todos os inputs invalidos e retornar um erro de validação",
+      function (Given, When, Then) {
+        //Arrangements
+        Given.iStartMyApp({
+          hash: "raca/2",
+        });
+        //Actions
+        When.naPaginaDeDetalhesDaRaca
+          .euSelecionoUmPersonagemNaLista("Legolas")
+          .and.euPressionoOBotaoEditarPersonagem()
+          .and.euDigitoUmNomeNoInputField("O*")
+          .and.euSelecionoUmaProfissao("5")
+          .and.euDigitoUmaIdadeNoInputField("-990")
+          .and.euDigitoUmaAlturaNoInputField("-1.97")
+          .and.euSelecionoCondicaoMorto()
+          .and.euSelecionoCondicaoVivo()
+          .and.euPressionoOBotaoEditarNoModal();
+
+        //Assertions
+        Then.naPaginaDeDetalhesDaRaca.deveAparecerUmaMessageBoxDeErro();
+
+        //Cleanup
+        Then.iTeardownMyApp();
+      }
+    );
   }
 );

--- a/Cod3rsGrowth.Web/wwwroot/test/integration/pages/DetalhesRaca.js
+++ b/Cod3rsGrowth.Web/wwwroot/test/integration/pages/DetalhesRaca.js
@@ -88,6 +88,18 @@ sap.ui.define(
                 "Não foi possível encontrar o botão adicionar personagem na página",
             });
           },
+          euPressionoOBotaoEditarNoModal: function () {
+            return this.waitFor({
+              controlType: "sap.m.Button",
+              matchers: new I18NText({
+                propertyName: "text",
+                key: "BotaoEditar",
+              }),
+              actions: new Press(),
+              errorMessage:
+                "Não foi possível encontrar o botão adicionar personagem na página",
+            });
+          },
           euDigitoUmNomeNoInputField: function (nomePersonagem) {
             return this.waitFor({
               id: ID_INPUT_NOME,
@@ -174,6 +186,35 @@ sap.ui.define(
                 Opa5.assert.ok(true, "O botão cancelar foi pressionado");
               },
               errorMessage: "Não foi possível encontrar o botao cancelar",
+            });
+          },
+          euPressionoOBotaoEditarPersonagem: function () {
+            return this.waitFor({
+              controlType: "sap.m.Button",
+              matchers: new I18NText({
+                propertyName: "text",
+                key: "BotaoEditarPersonagem",
+              }),
+              actions: new Press(),
+              success: function () {
+                Opa5.assert.ok(
+                  true,
+                  "O botão editar personagem foi pressionado"
+                );
+              },
+              errorMessage:
+                "Não foi possível encontrar o botao editar personagem",
+            });
+          },
+          euSelecionoUmPersonagemNaLista(nomeDoPersonagem) {
+            return this.waitFor({
+              controlType: "sap.m.ObjectIdentifier",
+              viewName: NOME_VIEW,
+              matchers: new Properties({
+                title: nomeDoPersonagem,
+              }),
+              actions: new Press(),
+              errorMessage: "Não foi possível selecionar o item na lista",
             });
           },
         },
@@ -376,6 +417,24 @@ sap.ui.define(
                 "Não foi encontrado o Modal de criação de personagem",
             });
           },
+          deveAparecerOModalDeEdicaoDePersonagem: function () {
+            return this.waitFor({
+              searchOpenDialogs: true,
+              controlType: "sap.m.Dialog",
+              matchers: new PropertyStrictEquals({
+                name: "title",
+                value: "Editar Personagem",
+              }),
+              success: function () {
+                Opa5.assert.ok(
+                  true,
+                  "Foi encontrada o Modal de edição de personagem"
+                );
+              },
+              errorMessage:
+                "Não foi encontrado o Modal de edição de personagem",
+            });
+          },
           deveAparecerUmaMessageBoxDeErro: function () {
             return this.waitFor({
               searchOpenDialogs: true,
@@ -408,6 +467,80 @@ sap.ui.define(
                 );
               },
               errorMessage: "Não foi encontrada a MessageBox indicando um erro",
+            });
+          },
+          oTituloDoModalDeveraSer: function () {
+            return this.waitFor({
+              searchOpenDialogs: true,
+              controlType: "sap.m.Dialog",
+              matchers: new PropertyStrictEquals({
+                name: "title",
+                value: "Editar Personagem",
+              }),
+              success: function () {
+                Opa5.assert.ok(
+                  true,
+                  "Foi encontrada o Modal de edição de personagem"
+                );
+              },
+              errorMessage:
+                "Não foi encontrado o Modal de edição de personagem",
+            });
+          },
+          deveAparecerUmBotaoDeEditarPersonagemNaTela: function () {
+            return this.waitFor({
+              controlType: "sap.m.Button",
+              matchers: new I18NText({
+                propertyName: "text",
+                key: "BotaoEditarPersonagem",
+              }),
+              success: function () {
+                Opa5.assert.ok(
+                  true,
+                  "O botão editar personagem foi encontrado"
+                );
+              },
+              errorMessage:
+                "Não foi possível encontrar o botao editar personagem",
+            });
+          },
+          oInputDeNomeDeveraEstarPreenchido: function (nomeDoPersonagem) {
+            return this.waitFor({
+              controlType: "sap.m.Input",
+              matchers: new I18NText({
+                propertyName: "placeholder",
+                key: "PlaceholderNome",
+              }),
+              success: function (input) {
+                this.waitFor({
+                  controlType: "sap.m.Input",
+                  matchers: new Properties({
+                    value: nomeDoPersonagem,
+                  }),
+                });
+                Opa5.assert.ok(
+                  input,
+                  "O input esta preenchido com o nome correto"
+                );
+              },
+              errorMessage: "Não foi encontrado o nome no input",
+            });
+          },
+          oTextoDoBotaoEditarDeveraSer: function () {
+            this.waitFor({
+              controlType: "sap.m.Button",
+              matchers: new I18NText({
+                propertyName: "text",
+                key: "BotaoEditar",
+              }),
+              success: function () {
+                Opa5.assert.ok(
+                  true,
+                  "O botão editar personagem foi encontrado"
+                );
+              },
+              errorMessage:
+                "Não foi possível encontrar o botao editar personagem",
             });
           },
         },

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
@@ -1,195 +1,196 @@
 sap.ui.define(
-  [
-    "../controller/BaseController",
-    "ui5/o_senhor_dos_aneis/services/RacaService",
-    "sap/ui/model/json/JSONModel",
-    "sap/m/MessageBox",
-    "ui5/o_senhor_dos_aneis/model/formatter",
-  ],
-  function (BaseController, RacaService, JSONModel, MessageBox, formatter) {
-    "use strict";
-    const ID_INPUT_NOME = "inputNome",
-      ID_RADIO_BTN_EXTINTAOUNAO = "radioBtnExtintaOuNao";
-    return BaseController.extend(
-      "ui5.o_senhor_dos_aneis.controller.CriarRaca",
-      {
-        formatter: formatter,
+    [
+        "../controller/BaseController",
+        "ui5/o_senhor_dos_aneis/services/RacaService",
+        "sap/ui/model/json/JSONModel",
+        "sap/m/MessageBox",
+        "ui5/o_senhor_dos_aneis/model/formatter",
+    ],
+    function (BaseController, RacaService, JSONModel, MessageBox, formatter) {
+        "use strict";
+        const ID_INPUT_NOME = "inputNome",
+            ID_RADIO_BTN_EXTINTAOUNAO = "radioBtnExtintaOuNao",
+            MODELO_RACA = "raca";
+        return BaseController.extend(
+            "ui5.o_senhor_dos_aneis.controller.CriarRaca",
+            {
+                formatter: formatter,
 
-        onInit: function () {
-          const rotaCriacao = "criarRaca";
-          const rotaEdicao = "editarRaca";
-          this.vincularRota(rotaCriacao, this.aoCoincidirRotaCriar);
-          this.vincularRota(rotaEdicao, this.aoCoincidirRotaEditar);
-        },
+                onInit: function () {
+                    const rotaCriacao = "criarRaca";
+                    const rotaEdicao = "editarRaca";
+                    this.vincularRota(rotaCriacao, this.aoCoincidirRotaCriar);
+                    this.vincularRota(rotaEdicao, this.aoCoincidirRotaEditar);
+                },
 
-        aoCoincidirRotaCriar: function (oEvent) {
-          this.filtros = {};
-          this.raca = {};
-          this.errosDeValidacao = {};
-          this.modoEditar = false;
-          this._limparInputs();
-          this._atualizarTextoDaPáginaCriar();
-        },
+                aoCoincidirRotaCriar: function (oEvent) {
+                    this.filtros = {};
+                    this.raca = {};
+                    this.errosDeValidacao = {};
+                    this.modoEditar = false;
+                    this._limparInputs();
+                    this._atualizarTextoDaPáginaCriar();
+                },
 
-        aoCoincidirRotaEditar: function (oEvent) {
-          this.filtros = {};
-          this.raca = {};
-          this.errosDeValidacao = {};
-          this.modoEditar = true;
-          this._limparInputs();
-          this._carregarDadosDaRacaSelecionada(oEvent);
-          this._atualizarTextoDaPáginaEditar();
-        },
+                aoCoincidirRotaEditar: function (oEvent) {
+                    this.filtros = {};
+                    this.raca = {};
+                    this.errosDeValidacao = {};
+                    this.modoEditar = true;
+                    this._limparInputs();
+                    this._carregarDadosDaRacaSelecionada(oEvent);
+                    this._atualizarTextoDaPáginaEditar();
+                },
 
-        aoMudarNome: function (oEvent) {
-          this._aoMudarInput(oEvent, this._validarNome.bind(this));
-        },
+                aoMudarNome: function (oEvent) {
+                    this._aoMudarInput(oEvent, this._validarNome.bind(this));
+                },
 
-        aoCriarRaca: async function (oEvent) {
-          this._pegarValoresDaRacaNaTela();
-          if (!this.modoEditar) {
-            if (this._validarNovaRaca(this.raca)) {
-              try {
-                const racaCriada = await RacaService.adicionarRaca(this.raca);
-                const mensagemDeSucesso = "Raça adicionada com sucesso!";
-                const tituloDaMessageBox = "Sucesso";
-                this.criarDialogoDeSucesso(
-                  mensagemDeSucesso,
-                  tituloDaMessageBox
-                );
-                this._limparInputs();
-              } catch (erros) {
-                this._exibirErros(erros);
-              }
+                aoCriarRaca: async function (oEvent) {
+                    this._pegarValoresDaRacaNaTela();
+                    if (!this.modoEditar) {
+                        if (this._validarNovaRaca(this.raca)) {
+                            try {
+                                const racaCriada = await RacaService.adicionarRaca(this.raca);
+                                const mensagemDeSucesso = "Raça adicionada com sucesso!";
+                                const tituloDaMessageBox = "Sucesso";
+                                this.criarDialogoDeSucesso(
+                                    mensagemDeSucesso,
+                                    tituloDaMessageBox
+                                );
+                                this._limparInputs();
+                            } catch (erros) {
+                                this._exibirErros(erros);
+                            }
+                        }
+                        return;
+                    }
+                    if (this._validarNovaRaca(this.raca)) {
+                        try {
+                            const racaEditada = await RacaService.editarRaca(this.raca);
+                            const mensagemDeSucesso = "Raça editada com sucesso!";
+                            const tituloDaMessageBox = "Sucesso";
+                            this.criarDialogoDeSucesso(mensagemDeSucesso, tituloDaMessageBox);
+                            this._limparInputs();
+                        } catch (erros) {
+                            this._exibirErros(erros);
+                        }
+                    }
+                },
+
+                onNavToListaDeRacas: function () {
+                    const rotaListaDeRacas = "listaDeRacas";
+                    this.onNavTo(rotaListaDeRacas);
+                },
+
+                _carregarDadosDaRacaSelecionada: async function (oEvent) {
+                    if (oEvent.getParameter("arguments").id) {
+                        try {
+                            const idRaca = oEvent.getParameter("arguments").id;
+                            const raca = await RacaService.obterRaca(idRaca);
+                            const modelo = new JSONModel(raca);
+
+
+                            this.getView().setModel(modelo, MODELO_RACA);
+                        } catch (erros) {
+                            this._exibirErros(erros);
+                        }
+                    }
+                },
+
+                _atualizarTextoDaPáginaCriar: function () {
+                    this._atualizarTituloDaPaginaCriar();
+                    this._atualizarLabelDoBotaoAdicionar();
+                },
+
+                _atualizarTextoDaPáginaEditar: function () {
+                    this._atualizarTituloDaPaginaEditar();
+                    this._atualizarLabelDoBotaoEditar();
+                },
+
+                _atualizarTituloDaPaginaCriar: function () {
+                    const idPaginaCriacao = "paginaCriarRaca";
+                    const chaveI18N = "TituloPaginaCriarRaca";
+                    this.byId(idPaginaCriacao).setTitle(this.obterTextoI18N(chaveI18N));
+                },
+
+                _atualizarTituloDaPaginaEditar: function () {
+                    const idPaginaCriacao = "paginaCriarRaca";
+                    const chaveI18N = "TituloPaginaEditarRaca";
+                    this.byId(idPaginaCriacao).setTitle(this.obterTextoI18N(chaveI18N));
+                },
+
+                _atualizarLabelDoBotaoAdicionar: function () {
+                    const idBotaoAdicionar = "criarRacaBtn";
+                    const chaveI18N = "BotaoAdicionar";
+                    this.byId(idBotaoAdicionar).setText(this.obterTextoI18N(chaveI18N));
+                },
+
+                _atualizarLabelDoBotaoEditar: function () {
+                    const idBotaoAdicionar = "criarRacaBtn";
+                    const chaveI18N = "BotaoEditar";
+                    this.byId(idBotaoAdicionar).setText(this.obterTextoI18N(chaveI18N));
+                },
+
+                _aoMudarInput: function (oEvent, funcaoDeValidacao) {
+                    const objeto = oEvent.getSource();
+                    const nomeInserido = objeto.getValue();
+                    let valueState = funcaoDeValidacao(nomeInserido)
+                        ? "Success"
+                        : "Error";
+                    objeto.setValueState(valueState);
+                },
+
+                _validarNovaRaca: function (raca) {
+                    let racaValida = false;
+                    const nomeInseridoInput = this._validarNome(raca.nome);
+                    if (nomeInseridoInput) {
+                        racaValida = true;
+                        return racaValida;
+                    }
+                    this._exibirErros(this.errosDeValidacao);
+                    return racaValida;
+                },
+
+                _pegarValoresDaRacaNaTela: function () {
+                    const modelo = this.getView().getModel("raca");
+
+                    const dadosDoModelo = modelo.getData();
+                    const condicaoExtinta = 0;
+                    const condicaoEstaExtintaNoModelo =
+                        this.byId(ID_RADIO_BTN_EXTINTAOUNAO).getSelectedIndex() ==
+                        condicaoExtinta
+                            ? true
+                            : false;
+
+                    this.raca = {
+                        id: dadosDoModelo.id,
+                        nome: dadosDoModelo.nome,
+                        localizacaoGeografica: dadosDoModelo.localizacaoGeografica,
+                        habilidadeRacial: dadosDoModelo.habilidadeRacial,
+                        estaExtinta: condicaoEstaExtintaNoModelo,
+                    };
+                },
+
+                _limparInputs: function () {
+                    const stringVazia = "";
+                    const condicaoInicial = 0;
+                    const valueStatePadrao = "None";
+
+
+                    const modelo = new JSONModel({
+                        nome: stringVazia,
+                        localizacaoGeografica: stringVazia,
+                        habilidadeRacial: stringVazia,
+                    });
+                    this.getView().setModel(modelo, MODELO_RACA);
+
+                    this.byId(ID_INPUT_NOME).setValueState(valueStatePadrao);
+                    this.byId(ID_RADIO_BTN_EXTINTAOUNAO).setSelectedIndex(
+                        condicaoInicial
+                    );
+                },
             }
-            return;
-          }
-          if (this._validarNovaRaca(this.raca)) {
-            try {
-              const racaEditada = await RacaService.editarRaca(this.raca);
-              const mensagemDeSucesso = "Raça editada com sucesso!";
-              const tituloDaMessageBox = "Sucesso";
-              this.criarDialogoDeSucesso(mensagemDeSucesso, tituloDaMessageBox);
-              this._limparInputs();
-            } catch (erros) {
-              this._exibirErros(erros);
-            }
-          }
-        },
-
-        onNavToListaDeRacas: function () {
-          const rotaListaDeRacas = "listaDeRacas";
-          this.onNavTo(rotaListaDeRacas);
-        },
-
-        _carregarDadosDaRacaSelecionada: async function (oEvent) {
-          if (oEvent.getParameter("arguments").id) {
-            try {
-              const idRaca = oEvent.getParameter("arguments").id;
-              const raca = await RacaService.obterRaca(idRaca);
-              const modelo = new JSONModel(raca);
-              const modeloRaca = "raca";
-
-              this.getView().setModel(modelo, modeloRaca);
-            } catch (erros) {
-              this._exibirErros(erros);
-            }
-          }
-        },
-
-        _atualizarTextoDaPáginaCriar: function () {
-          this._atualizarTituloDaPaginaCriar();
-          this._atualizarLabelDoBotaoAdicionar();
-        },
-
-        _atualizarTextoDaPáginaEditar: function () {
-          this._atualizarTituloDaPaginaEditar();
-          this._atualizarLabelDoBotaoEditar();
-        },
-
-        _atualizarTituloDaPaginaCriar: function () {
-          const idPaginaCriacao = "paginaCriarRaca";
-          const chaveI18N = "TituloPaginaCriarRaca";
-          this.byId(idPaginaCriacao).setTitle(this.obterTextoI18N(chaveI18N));
-        },
-
-        _atualizarTituloDaPaginaEditar: function () {
-          const idPaginaCriacao = "paginaCriarRaca";
-          const chaveI18N = "TituloPaginaEditarRaca";
-          this.byId(idPaginaCriacao).setTitle(this.obterTextoI18N(chaveI18N));
-        },
-
-        _atualizarLabelDoBotaoAdicionar: function () {
-          const idBotaoAdicionar = "criarRacaBtn";
-          const chaveI18N = "BotaoAdicionar";
-          this.byId(idBotaoAdicionar).setText(this.obterTextoI18N(chaveI18N));
-        },
-
-        _atualizarLabelDoBotaoEditar: function () {
-          const idBotaoAdicionar = "criarRacaBtn";
-          const chaveI18N = "BotaoEditar";
-          this.byId(idBotaoAdicionar).setText(this.obterTextoI18N(chaveI18N));
-        },
-
-        _aoMudarInput: function (oEvent, funcaoDeValidacao) {
-          const objeto = oEvent.getSource();
-          const nomeInserido = objeto.getValue();
-          let valueState = funcaoDeValidacao(nomeInserido)
-            ? "Success"
-            : "Error";
-          objeto.setValueState(valueState);
-        },
-
-        _validarNovaRaca: function (raca) {
-          let racaValida = false;
-          const nomeInseridoInput = this._validarNome(raca.nome);
-          if (nomeInseridoInput) {
-            racaValida = true;
-            return racaValida;
-          }
-          this._exibirErros(this.errosDeValidacao);
-          return racaValida;
-        },
-
-        _pegarValoresDaRacaNaTela: function () {
-          const modelo = this.getView().getModel("raca");
-
-          const dadosDoModelo = modelo.getData();
-          const condicaoExtinta = 0;
-          const condicaoEstaExtintaNoModelo =
-            this.byId(ID_RADIO_BTN_EXTINTAOUNAO).getSelectedIndex() ==
-            condicaoExtinta
-              ? true
-              : false;
-
-          this.raca = {
-            id: dadosDoModelo.id,
-            nome: dadosDoModelo.nome,
-            localizacaoGeografica: dadosDoModelo.localizacaoGeografica,
-            habilidadeRacial: dadosDoModelo.habilidadeRacial,
-            estaExtinta: condicaoEstaExtintaNoModelo,
-          };
-        },
-
-        _limparInputs: function () {
-          const stringVazia = "";
-          const condicaoInicial = 0;
-          const valueStatePadrao = "None";
-
-          const modeloRaca = "raca";
-          const modelo = new JSONModel({
-            nome: stringVazia,
-            localizacaoGeografica: stringVazia,
-            habilidadeRacial: stringVazia,
-          });
-          this.getView().setModel(modelo, modeloRaca);
-
-          this.byId(ID_INPUT_NOME).setValueState(valueStatePadrao);
-          this.byId(ID_RADIO_BTN_EXTINTAOUNAO).setSelectedIndex(
-            condicaoInicial
-          );
-        },
-      }
-    );
-  }
+        );
+    }
 );

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
@@ -29,7 +29,7 @@ sap.ui.define(
                     this.errosDeValidacao = {};
                     this.modoEditar = false;
                     this._limparInputs();
-                    this._atualizarTextoDaPáginaCriar();
+                    this._atualizarTextoDaPaginaCriar();
                 },
 
                 aoCoincidirRotaEditar: function (oEvent) {
@@ -39,7 +39,7 @@ sap.ui.define(
                     this.modoEditar = true;
                     this._limparInputs();
                     this._carregarDadosDaRacaSelecionada(oEvent);
-                    this._atualizarTextoDaPáginaEditar();
+                    this._atualizarTextoDaPaginaEditar();
                 },
 
                 aoMudarNome: function (oEvent) {
@@ -98,12 +98,12 @@ sap.ui.define(
                     }
                 },
 
-                _atualizarTextoDaPáginaCriar: function () {
+                _atualizarTextoDaPaginaCriar: function () {
                     this._atualizarTituloDaPaginaCriar();
                     this._atualizarLabelDoBotaoAdicionar();
                 },
 
-                _atualizarTextoDaPáginaEditar: function () {
+                _atualizarTextoDaPaginaEditar: function () {
                     this._atualizarTituloDaPaginaEditar();
                     this._atualizarLabelDoBotaoEditar();
                 },

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
@@ -90,7 +90,6 @@ sap.ui.define(
                             const raca = await RacaService.obterRaca(idRaca);
                             const modelo = new JSONModel(raca);
 
-
                             this.getView().setModel(modelo, MODELO_RACA);
                         } catch (erros) {
                             this._exibirErros(erros);

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/DetalhesRaca.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/DetalhesRaca.controller.js
@@ -38,6 +38,7 @@ sap.ui.define(
           this.personagem = {};
           this.errosDeValidacao = {};
           this._carregarDados(oEvent);
+          this._mostrarBotoesDeEditarERemoverPersonagem(false);
         },
 
         aoClicarBtnEditarRaca: function () {
@@ -72,9 +73,13 @@ sap.ui.define(
           this._carregarModalDeCriacao();
         },
 
-        aoClicarBtnEditarPersonagem: function (oEvent) {
-          this._buscarDadosDoPersonagemSelecionadoNaLista(oEvent);
+        aoClicarBtnEditarPersonagem: function () {
           this._carregarModalDeCriacao();
+        },
+
+        aoSelecionarItemNaListaDePersonagem: function (oEvent) {
+          this._buscarDadosDoPersonagemSelecionadoNaLista(oEvent);
+          this._mostrarBotoesDeEditarERemoverPersonagem(true);
         },
 
         aoClicarBtnAdicionarNoModal: async function (oEvent) {
@@ -113,6 +118,7 @@ sap.ui.define(
         aoClicarBtnCancelarNoModal: function (oEvent) {
           this.byId(ID_MODAL_CRIAR_PERSONAGEM).close();
           this._limparInputs(oEvent);
+          this._mostrarBotoesDeEditarERemoverPersonagem(false);
         },
 
         _carregarModalDeCriacao: async function () {
@@ -283,6 +289,10 @@ sap.ui.define(
           const idBotaoAdicionar = "criarPersonagemModalBtn";
           const chaveI18N = "BotaoEditar";
           this.byId(idBotaoAdicionar).setText(this.obterTextoI18N(chaveI18N));
+        },
+        _mostrarBotoesDeEditarERemoverPersonagem: function (visibilidade) {
+          this.byId("removerPersonagemBtn").setVisible(visibilidade);
+          this.byId("editarPersonagemBtn").setVisible(visibilidade);
         },
       }
     );

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/DetalhesRaca.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/DetalhesRaca.controller.js
@@ -69,7 +69,7 @@ sap.ui.define(
         },
 
         aoClicarBtnAdicionarPersonagem: function (oEvent) {
-          this._carregarModeloVazioDePersonagem();
+          this._carregarModeloDeNovoPersonagem();
           this._carregarModalDeCriacao();
         },
 
@@ -224,7 +224,26 @@ sap.ui.define(
 
           const modelo = new JSONModel({
             nome: stringVazia,
-            idRaca: this.personagem.idRaca,
+            idRaca: oEvent.getParameter("arguments").id,
+            profissao: stringVazia,
+            altura: stringVazia,
+            idade: stringVazia,
+            estaVivo: condicaoInicial,
+          });
+
+          this.getView().setModel(modelo, MODELO_PERSONAGEM);
+        },
+
+        _carregarModeloDeNovoPersonagem: function () {
+          const stringVazia = "";
+          const condicaoInicial = 0;
+
+          const modeloRaca = this.getView().getModel(MODELO_RACA);
+          const idRaca = modeloRaca.getProperty("/id");
+
+          const modelo = new JSONModel({
+            nome: stringVazia,
+            idRaca: idRaca,
             profissao: stringVazia,
             altura: stringVazia,
             idade: stringVazia,

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/DetalhesRaca.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/DetalhesRaca.controller.js
@@ -69,6 +69,19 @@ sap.ui.define(
           this.modalCriarPersonagem.open();
         },
 
+        aoEditarPersonagem: async function () {
+          this._mostrarBotoesEditarERemover(false);
+          this.modalCriarPersonagem ??= await this.loadFragment({
+            name: "ui5.o_senhor_dos_aneis.view.CriarPersonagensModal",
+          });
+
+          this.modalCriarPersonagem.open();
+        },
+
+        aoSelecionarItemNaListaDePersonagens: function () {
+          this._mostrarBotoesEditarERemover(true);
+        },
+
         aoPressionarAdicionarNoModal: async function (oEvent) {
           this._pegarValoresDoPersonagemNoModalNaTela();
           if (this._validarNovoPersonagem(this.personagem)) {
@@ -114,6 +127,11 @@ sap.ui.define(
           };
         },
 
+        _mostrarBotoesEditarERemover: function (valor) {
+          this.byId("editarPersonagemBtn").setVisible(valor);
+          this.byId("removerPersonagemBtn").setVisible(valor);
+        },
+
         _carregarModelos: async function (oEvent) {
           this._carregarModeloDaRaca(oEvent);
           this._carregarModeloDePersonagens(oEvent);
@@ -144,6 +162,13 @@ sap.ui.define(
             const modeloPersonagens = "personagens";
 
             this.getView().setModel(modelo, modeloPersonagens);
+          } catch (erros) {
+            this._exibirErros(erros);
+          }
+        },
+        _carrgarModeloPersonagemSelecionado: async function (oEvent) {
+          try {
+            const idPersonagemSelecionado = oEvent.getParameter("arguments").id;
           } catch (erros) {
             this._exibirErros(erros);
           }

--- a/Cod3rsGrowth.Web/wwwroot/webapp/services/PersonagemService.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/services/PersonagemService.js
@@ -5,6 +5,7 @@ sap.ui.define(["sap/m/MessageBox"], function (MessageBox) {
     "https://localhost:7244/api/Personagem/personagens";
   const URL_POST_PERSONAGEM =
     "https://localhost:7244/api/Personagem/personagem";
+  const URL_PUT_PERSONAGEM = "https://localhost:7244/api/Personagem/personagem";
 
   return {
     obterTodos: async function (filtros) {
@@ -37,6 +38,31 @@ sap.ui.define(["sap/m/MessageBox"], function (MessageBox) {
         });
         if (!response.ok) {
           throw await response.json();
+        }
+        if (response.status == 200) {
+          return;
+        }
+        return await response.json();
+      } catch (erro) {
+        throw erro;
+      }
+    },
+    editarPersonagem: async function (personagem) {
+      let urlPersonagens = new URL(URL_PUT_PERSONAGEM);
+
+      try {
+        const response = await fetch(urlPersonagens.href, {
+          method: "PUT",
+          body: JSON.stringify(personagem),
+          headers: {
+            "Content-type": "application/json; charset=UTF-8",
+          },
+        });
+        if (!response.ok) {
+          throw await response.json();
+        }
+        if (response.status == 200) {
+          return;
         }
         return await response.json();
       } catch (erro) {

--- a/Cod3rsGrowth.Web/wwwroot/webapp/view/CriarPersonagensModal.fragment.xml
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/view/CriarPersonagensModal.fragment.xml
@@ -5,7 +5,7 @@
 >
     <Dialog
         id="modalCriarPersonagem"
-        title="{i18n>TituloPaginaCriarPersonagem}"
+        title="{i18n>TituloModalCriarPersonagem}"
         class="sapUiContentPadding"
     >
         <FlexBox>
@@ -170,7 +170,7 @@
         <beginButton>
             <Button
                 text="{i18n>BotaoAdicionar}"
-                press=".aoPressionarAdicionarNoModal"
+                press=".aoClicarBtnAdicionarNoModal"
                 id="criarPersonagemModalBtn"
                 type="Accept"
             />
@@ -178,7 +178,7 @@
         <endButton>
             <Button
                 text="{i18n>BotaoCancelar}"
-                press=".aoPressionarCancelarNoModal"
+                press=".aoClicarBtnCancelarNoModal"
                 id="cancelarCriarPersonagemModalBtn"
                 type="Reject"
             />

--- a/Cod3rsGrowth.Web/wwwroot/webapp/view/DetalhesRaca.view.xml
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/view/DetalhesRaca.view.xml
@@ -93,12 +93,14 @@
 
         <List
             id="listaDePersonagens"
-            mode="None"
+            mode="Delete"
+            delete="aoRemoverPersonagem"
             items="{personagens>/}"
             growing="true"
             growingThreshold="5"
             enableBusyIndicator="true"
             class="sapUiResponsiveContentPadding"
+            itemPress=".aoSelecionarItemNaListaDePersonagens"
         >
             <headerToolbar>
                 <OverflowToolbar id="listToolbar">
@@ -108,7 +110,8 @@
             </headerToolbar>
 
             <CustomListItem
-                type="Navigation"
+                type="Detail"
+                detailPress="aoEditarPersonagem"
                 id="customListPersonagens"
                 highlight="{
                 path: 'personagens>estaVivo',
@@ -170,6 +173,7 @@
                                 }"
                             />
                         </FlexBox>
+                        
                     </VBox>
                 </HBox>
             </CustomListItem>
@@ -186,6 +190,30 @@
                     class="sapUiTinyMarginEnd"
                 >
                     <layoutData>
+                        <OverflowToolbarLayoutData priority="High" />
+                    </layoutData>
+                </Button>
+                        <Button
+                            type="Emphasized"
+                            text="{i18n>BotaoEditarPersonagem}"
+                            press=".aoEditarPersonagem"
+                            id="editarPersonagemBtn"
+                            class="sapUiTinyMarginEnd"
+                            visible="false"
+                        >
+                    <layoutData>
+                        <OverflowToolbarLayoutData priority="High" />
+                    </layoutData>
+                </Button>
+                        <Button
+                            type="Reject"
+                            text="{i18n>BotaoRemoverPersonagem}"
+                            press=".aoRemoverPersonagem"
+                            id="removerPersonagemBtn"
+                            class="sapUiTinyMarginEnd"
+                            visible="false"
+                        >
+                        <layoutData>
                         <OverflowToolbarLayoutData priority="High" />
                     </layoutData>
                 </Button>

--- a/Cod3rsGrowth.Web/wwwroot/webapp/view/DetalhesRaca.view.xml
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/view/DetalhesRaca.view.xml
@@ -70,7 +70,7 @@
                 type="Emphasized"
                 text="{i18n>BotaoEditar}"
                 id="editarRacaBtn"
-                press=".onNavToEditarRaca"
+                press=".aoClicarBtnEditarRaca"
                 class="sapUiTinyMarginTop sapUiTinyMarginBottom"
                 width="100px"
             >
@@ -81,7 +81,7 @@
             <Button
                 type="Reject"
                 text="{i18n>BotaoRemover}"
-                press=".aoPressionarOBotaoRemover"
+                press=".aoClicarBtnRemoverRaca"
                 width="100px"
                 class="sapUiTinyMarginTop sapUiTinyMarginBottom"
             >
@@ -94,13 +94,12 @@
         <List
             id="listaDePersonagens"
             mode="Delete"
-            delete="aoRemoverPersonagem"
+            delete="aoClicarBtnRemoverPersonagem"
             items="{personagens>/}"
             growing="true"
             growingThreshold="5"
             enableBusyIndicator="true"
             class="sapUiResponsiveContentPadding"
-            itemPress=".aoSelecionarItemNaListaDePersonagens"
         >
             <headerToolbar>
                 <OverflowToolbar id="listToolbar">
@@ -111,7 +110,8 @@
 
             <CustomListItem
                 type="Detail"
-                detailPress="aoEditarPersonagem"
+                detailPress="aoClicarBtnEditarPersonagem"
+                press=".aoSelecionarItem"
                 id="customListPersonagens"
                 highlight="{
                 path: 'personagens>estaVivo',
@@ -173,7 +173,6 @@
                                 }"
                             />
                         </FlexBox>
-                        
                     </VBox>
                 </HBox>
             </CustomListItem>
@@ -185,7 +184,7 @@
                 <Button
                     type="Accept"
                     text="{i18n>BotaoAdicionarPersonagem}"
-                    press=".aoAdicionarPersonagem"
+                    press=".aoClicarBtnAdicionarPersonagem"
                     id="adicionarPersonagemBtn"
                     class="sapUiTinyMarginEnd"
                 >
@@ -193,27 +192,27 @@
                         <OverflowToolbarLayoutData priority="High" />
                     </layoutData>
                 </Button>
-                        <Button
-                            type="Emphasized"
-                            text="{i18n>BotaoEditarPersonagem}"
-                            press=".aoEditarPersonagem"
-                            id="editarPersonagemBtn"
-                            class="sapUiTinyMarginEnd"
-                            visible="false"
-                        >
+                <Button
+                    type="Emphasized"
+                    text="{i18n>BotaoEditarPersonagem}"
+                    press=".aoClicarBtnEditarPersonagem"
+                    id="editarPersonagemBtn"
+                    class="sapUiTinyMarginEnd"
+                    visible="false"
+                >
                     <layoutData>
                         <OverflowToolbarLayoutData priority="High" />
                     </layoutData>
                 </Button>
-                        <Button
-                            type="Reject"
-                            text="{i18n>BotaoRemoverPersonagem}"
-                            press=".aoRemoverPersonagem"
-                            id="removerPersonagemBtn"
-                            class="sapUiTinyMarginEnd"
-                            visible="false"
-                        >
-                        <layoutData>
+                <Button
+                    type="Reject"
+                    text="{i18n>BotaoRemoverPersonagem}"
+                    press=".aoRemoverPersonagem"
+                    id="removerPersonagemBtn"
+                    class="sapUiTinyMarginEnd"
+                    visible="false"
+                >
+                    <layoutData>
                         <OverflowToolbarLayoutData priority="High" />
                     </layoutData>
                 </Button>

--- a/Cod3rsGrowth.Web/wwwroot/webapp/view/DetalhesRaca.view.xml
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/view/DetalhesRaca.view.xml
@@ -192,30 +192,6 @@
                         <OverflowToolbarLayoutData priority="High" />
                     </layoutData>
                 </Button>
-                <Button
-                    type="Emphasized"
-                    text="{i18n>BotaoEditarPersonagem}"
-                    press=".aoClicarBtnEditarPersonagem"
-                    id="editarPersonagemBtn"
-                    class="sapUiTinyMarginEnd"
-                    visible="false"
-                >
-                    <layoutData>
-                        <OverflowToolbarLayoutData priority="High" />
-                    </layoutData>
-                </Button>
-                <Button
-                    type="Reject"
-                    text="{i18n>BotaoRemoverPersonagem}"
-                    press=".aoRemoverPersonagem"
-                    id="removerPersonagemBtn"
-                    class="sapUiTinyMarginEnd"
-                    visible="false"
-                >
-                    <layoutData>
-                        <OverflowToolbarLayoutData priority="High" />
-                    </layoutData>
-                </Button>
             </OverflowToolbar>
         </footer>
     </Page>

--- a/Cod3rsGrowth.Web/wwwroot/webapp/view/DetalhesRaca.view.xml
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/view/DetalhesRaca.view.xml
@@ -93,8 +93,6 @@
 
         <List
             id="listaDePersonagens"
-            mode="Delete"
-            delete="aoClicarBtnRemoverPersonagem"
             items="{personagens>/}"
             growing="true"
             growingThreshold="5"
@@ -109,9 +107,8 @@
             </headerToolbar>
 
             <CustomListItem
-                type="Detail"
-                detailPress="aoClicarBtnEditarPersonagem"
-                press=".aoSelecionarItem"
+                type="Active"
+                press=".aoSelecionarItemNaListaDePersonagem"
                 id="customListPersonagens"
                 highlight="{
                 path: 'personagens>estaVivo',
@@ -187,6 +184,30 @@
                     press=".aoClicarBtnAdicionarPersonagem"
                     id="adicionarPersonagemBtn"
                     class="sapUiTinyMarginEnd"
+                >
+                    <layoutData>
+                        <OverflowToolbarLayoutData priority="High" />
+                    </layoutData>
+                </Button>
+                <Button
+                    type="Emphasized"
+                    text="{i18n>BotaoEditarPersonagem}"
+                    press=".aoClicarBtnEditarPersonagem"
+                    id="editarPersonagemBtn"
+                    class="sapUiTinyMarginEnd"
+                    visible="false"
+                >
+                    <layoutData>
+                        <OverflowToolbarLayoutData priority="High" />
+                    </layoutData>
+                </Button>
+                <Button
+                    type="Reject"
+                    text="{i18n>BotaoRemoverPersonagem}"
+                    press=".aoClicarBtnRemoverPersonagem"
+                    id="removerPersonagemBtn"
+                    class="sapUiTinyMarginEnd"
+                    visible="false"
                 >
                     <layoutData>
                         <OverflowToolbarLayoutData priority="High" />


### PR DESCRIPTION
1. Utilizado a mesma modal ou diálogo existente na tela de detalhes para a edição dos registros filhos.
2. Adaptado a lógica na modal para preencher os campos com os detalhes atuais do registro filho quando for uma operação de edição, e manter os campos vazios para uma operação de criação.
3. Na controller da modal, ajustado a lógica para determinar se a operação é de criação ou edição com base nos dados fornecidos.
4. Garantido que a lógica de envio de dados para a API seja adequada para lidar com operações de edição, enviando os dados atualizados em vez de criar um novo registro.
5. Escrito testes OPA para verificar se a modal de edição está funcionando corretamente, tanto para operações de criação quanto de edição, e se os dados são enviados para a API conforme esperado.