### PR TITLE
Implementar na tela de detalhes a remocao dos registros filhos

### DIFF
--- a/Cod3rsGrowth.Web/Cod3rsGrowth.Web.csproj.user
+++ b/Cod3rsGrowth.Web/Cod3rsGrowth.Web.csproj.user
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Controller_SelectedScaffolderID>ApiControllerEmptyScaffolder</Controller_SelectedScaffolderID>
     <Controller_SelectedScaffolderCategoryPath>root/Common/Api</Controller_SelectedScaffolderCategoryPath>
-    <ActiveDebugProfile>https-Teste</ActiveDebugProfile>
+    <ActiveDebugProfile>https</ActiveDebugProfile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>

--- a/Cod3rsGrowth.Web/Cod3rsGrowth.Web.csproj.user
+++ b/Cod3rsGrowth.Web/Cod3rsGrowth.Web.csproj.user
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Controller_SelectedScaffolderID>ApiControllerEmptyScaffolder</Controller_SelectedScaffolderID>
     <Controller_SelectedScaffolderCategoryPath>root/Common/Api</Controller_SelectedScaffolderCategoryPath>
-    <ActiveDebugProfile>https</ActiveDebugProfile>
+    <ActiveDebugProfile>https-Teste</ActiveDebugProfile>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebuggerFlavor>ProjectDebugger</DebuggerFlavor>

--- a/Cod3rsGrowth.Web/wwwroot/test/integration/journeys/DetalhesRacaJourney.js
+++ b/Cod3rsGrowth.Web/wwwroot/test/integration/journeys/DetalhesRacaJourney.js
@@ -110,7 +110,7 @@ sap.ui.define(
       "Deve pressionar para confirmar a exclusao do registro pai com filhos e retornar um erro",
       function (Given, When, Then) {
         //Actions
-        When.naPaginaDeDetalhesDaRaca.euPressionoSimParaConfirmarAEsclusao();
+        When.naPaginaDeDetalhesDaRaca.euPressionoSimParaConfirmarAExclusao();
 
         //Assertions
         Then.naPaginaDeDetalhesDaRaca.deveAparecerUmaMessageBoxDeErroDeRegistroDeDependentes();
@@ -250,7 +250,8 @@ sap.ui.define(
         //Actions
         When.naPaginaDeDetalhesDaRaca
           .euPressionoOBotaoAdicionarPersonagem()
-          .and.euPressionoOBotaoCancelar();
+          .and.euPressionoOBotaoCancelar()
+          .and.euPressionoSimParaConfirmaroCancelamento();
 
         // Assertions
         Then.naPaginaDeDetalhesDaRaca.oTituloDaPaginaDetalhesDaRacaDeveraSer();
@@ -301,7 +302,9 @@ sap.ui.define(
       "Deve pressionar o botao cancelar no modal e deve permancer na pagina de detalhes",
       function (Given, When, Then) {
         //Actions
-        When.naPaginaDeDetalhesDaRaca.euPressionoOBotaoCancelar();
+        When.naPaginaDeDetalhesDaRaca
+          .euPressionoOBotaoCancelar()
+          .and.euPressionoSimParaConfirmaroCancelamento();
 
         //Assertions
         Then.naPaginaDeDetalhesDaRaca.oTituloDaPaginaDetalhesDaRacaDeveraSer();
@@ -331,6 +334,65 @@ sap.ui.define(
 
         //Assertions
         Then.naPaginaDeDetalhesDaRaca.deveAparecerUmaMessageBoxDeErro();
+
+        //Cleanup
+        Then.iTeardownMyApp();
+      }
+    );
+    opaTest(
+      "Deve pressionar o botao adicionar e abria a modal de criaçao de personagem",
+      function (Given, When, Then) {
+        // Arrangements
+        Given.iStartMyApp({
+          hash: "raca/2",
+        });
+        //Actions
+        When.naPaginaDeDetalhesDaRaca.euPressionoOBotaoAdicionarPersonagem();
+
+        // Assertions
+        Then.naPaginaDeDetalhesDaRaca.deveAparecerOModalDeCriacaoDePersonagem();
+      }
+    );
+    opaTest(
+      "Deve inserir os detalhes do novo personagem, criar a lista deve conter o novo personagem",
+      function (Given, When, Then) {
+        //Actions
+        When.naPaginaDeDetalhesDaRaca
+          .euDigitoUmNomeNoInputField("NovoElfo")
+          .and.euSelecionoUmaProfissao("5")
+          .and.euDigitoUmaIdadeNoInputField("990")
+          .and.euDigitoUmaAlturaNoInputField("1.97")
+          .and.euSelecionoCondicaoMorto()
+          .and.euSelecionoCondicaoVivo()
+          .and.euPressionoOBotaoAdicionar()
+          .and.euPressionoOkNaMessageBoxDeSucesso();
+
+        //Assertions
+        Then.naPaginaDeDetalhesDaRaca.euVerificoSeAListaTem4Registros();
+      }
+    );
+    opaTest(
+      "Deve selecionar o personagem recem criado e pressionar o botao remover personagem",
+      function (Given, When, Then) {
+        //Actions
+        When.naPaginaDeDetalhesDaRaca
+          .euSelecionoUmPersonagemNaLista("NovoElfo")
+          .and.euPressionoOBotaoRemoverPersonagem();
+
+        // Assertions
+        Then.naPaginaDeDetalhesDaRaca.deveAparecerUmaMessageBoxDeConfirmacao();
+      }
+    );
+    opaTest(
+      "Deve confirmar a exclusão do registro e a lista deve estar sem o registro removido",
+      function (Given, When, Then) {
+        //Actions
+        When.naPaginaDeDetalhesDaRaca
+          .euPressionoSimParaConfirmarAExclusao()
+          .and.euPressionoOkNaMessageBoxDeSucesso();
+
+        // Assertions
+        Then.naPaginaDeDetalhesDaRaca.euVerificoSeAListaTem3Registros();
 
         //Cleanup
         Then.iTeardownMyApp();

--- a/Cod3rsGrowth.Web/wwwroot/test/integration/journeys/EditarRacaJourney.js
+++ b/Cod3rsGrowth.Web/wwwroot/test/integration/journeys/EditarRacaJourney.js
@@ -207,9 +207,6 @@ sap.ui.define(
 
         // Assertions
         Then.naPaginaDeEditarRaca.deveAparecerUmaMessageBoxDeSucesso();
-        Then.naPaginaDaListaDeRacas
-          .oTituloDaPaginaDeRacasDeveraSer()
-          .and.aUrlDaPaginaDeRacasDeveraSer();
         // Cleanup
         Then.iTeardownMyApp();
       }

--- a/Cod3rsGrowth.Web/wwwroot/test/integration/journeys/ListaRacasJourney.js
+++ b/Cod3rsGrowth.Web/wwwroot/test/integration/journeys/ListaRacasJourney.js
@@ -108,7 +108,6 @@ sap.ui.define(
           .and.euPressionoOBotaoAdicionar();
 
         //Assertions
-        Then.naPaginaDeCriarRaca.deveAparecerUmaMessageBoxDeSucesso();
         Then.naPaginaDaListaDeRacas
           .oTituloDaPaginaDeRacasDeveraSer()
           .and.aUrlDaPaginaDeRacasDeveraSer();
@@ -132,7 +131,7 @@ sap.ui.define(
       "Deve confirmar a exclusão do registro e voltar para a página de listagem",
       function (Given, When, Then) {
         //Actions
-        When.naPaginaDeDetalhesDaRaca.euPressionoSimParaConfirmarAEsclusao();
+        When.naPaginaDeDetalhesDaRaca.euPressionoSimParaConfirmarAExclusao();
 
         // Assertions
         Then.naPaginaDaListaDeRacas

--- a/Cod3rsGrowth.Web/wwwroot/test/integration/pages/CriarRaca.js
+++ b/Cod3rsGrowth.Web/wwwroot/test/integration/pages/CriarRaca.js
@@ -4,9 +4,17 @@ sap.ui.define(
     "sap/ui/test/actions/Press",
     "sap/ui/test/actions/EnterText",
     "sap/ui/test/matchers/PropertyStrictEquals",
+    "sap/ui/test/matchers/Properties",
     "sap/ui/test/matchers/I18NText",
   ],
-  function (Opa5, Press, EnterText, PropertyStrictEquals, I18NText) {
+  function (
+    Opa5,
+    Press,
+    EnterText,
+    PropertyStrictEquals,
+    Properties,
+    I18NText
+  ) {
     "use strict";
 
     const NOME_VIEW = "CriarRaca",
@@ -116,6 +124,18 @@ sap.ui.define(
               actions: new Press(),
               errorMessage:
                 "Não foi possível encontrar o botão voltar na página",
+            });
+          },
+          euPressionoOkNaMessageBoxDeSucesso: function () {
+            return this.waitFor({
+              searchOpenDialogs: true,
+              controlType: "sap.m.Button",
+              matchers: new Properties({
+                text: "OK",
+              }),
+              actions: new Press(),
+              errorMessage:
+                "Não foi possível pressionar o botão 'OK' para fechar o diálogo",
             });
           },
         },

--- a/Cod3rsGrowth.Web/wwwroot/test/integration/pages/DetalhesRaca.js
+++ b/Cod3rsGrowth.Web/wwwroot/test/integration/pages/DetalhesRaca.js
@@ -64,7 +64,7 @@ sap.ui.define(
                 "Não foi possível encontrar o botão remover na página",
             });
           },
-          euPressionoSimParaConfirmarAEsclusao: function () {
+          euPressionoSimParaConfirmarAExclusao: function () {
             return this.waitFor({
               controlType: "sap.m.Button",
               matchers: [
@@ -74,6 +74,30 @@ sap.ui.define(
               actions: new Press(),
               errorMessage:
                 "Não foi possível pressionar o botão 'Sim' para confirmar a exclusão",
+            });
+          },
+          euPressionoSimParaConfirmaroCancelamento: function () {
+            return this.waitFor({
+              controlType: "sap.m.Button",
+              matchers: [
+                new Properties({ text: "Sim" }),
+                new Ancestor(Opa5.getContext().dialog, false),
+              ],
+              actions: new Press(),
+              errorMessage:
+                "Não foi possível pressionar o botão 'Sim' para confirmar a exclusão",
+            });
+          },
+          euPressionoOkNaMessageBoxDeSucesso: function () {
+            return this.waitFor({
+              searchOpenDialogs: true,
+              controlType: "sap.m.Button",
+              matchers: new Properties({
+                text: "OK",
+              }),
+              actions: new Press(),
+              errorMessage:
+                "Não foi possível pressionar o botão 'OK' para fechar o diálogo",
             });
           },
           euPressionoOBotaoAdicionarPersonagem: function () {
@@ -86,6 +110,18 @@ sap.ui.define(
               actions: new Press(),
               errorMessage:
                 "Não foi possível encontrar o botão adicionar personagem na página",
+            });
+          },
+          euPressionoOBotaoRemoverPersonagem: function () {
+            return this.waitFor({
+              controlType: "sap.m.Button",
+              matchers: new I18NText({
+                propertyName: "text",
+                key: "BotaoRemoverPersonagem",
+              }),
+              actions: new Press(),
+              errorMessage:
+                "Não foi possível encontrar o botão remover personagem na página",
             });
           },
           euPressionoOBotaoEditarNoModal: function () {
@@ -541,6 +577,34 @@ sap.ui.define(
               },
               errorMessage:
                 "Não foi possível encontrar o botao editar personagem",
+            });
+          },
+          euVerificoSeAListaTem4Registros: function () {
+            return this.waitFor({
+              id: ID_LISTA_REGISTROS_FILHOS,
+              viewName: NOME_VIEW,
+              success: function (lista) {
+                const modeloDaLista = lista.getModel("personagens");
+                const listaDeRacas = modeloDaLista.getProperty("/");
+                if (listaDeRacas.length === 4) {
+                  Opa5.assert.ok(true, "A lista tem 4 registros");
+                }
+              },
+              errorMessage: "A lista não contem 4 registros",
+            });
+          },
+          euVerificoSeAListaTem3Registros: function () {
+            return this.waitFor({
+              id: ID_LISTA_REGISTROS_FILHOS,
+              viewName: NOME_VIEW,
+              success: function (lista) {
+                const modeloDaLista = lista.getModel("personagens");
+                const listaDeRacas = modeloDaLista.getProperty("/");
+                if (listaDeRacas.length === 3) {
+                  Opa5.assert.ok(true, "A lista tem 3 registros");
+                }
+              },
+              errorMessage: "A lista não contem 3 registros",
             });
           },
         },

--- a/Cod3rsGrowth.Web/wwwroot/test/integration/pages/ListaRacas.js
+++ b/Cod3rsGrowth.Web/wwwroot/test/integration/pages/ListaRacas.js
@@ -1,203 +1,215 @@
 sap.ui.define(
-    [
-        "sap/ui/test/Opa5",
-        "sap/ui/test/matchers/AggregationLengthEquals",
-        "sap/ui/test/matchers/Properties",
-        "sap/ui/test/actions/Press",
-        "sap/ui/test/actions/EnterText",
-        "sap/ui/test/matchers/PropertyStrictEquals",
-    ],
-    function (
-        Opa5,
-        AggregationLengthEquals,
-        Properties,
-        Press,
-        EnterText,
-        PropertyStrictEquals
-    ) {
-        "use strict";
+  [
+    "sap/ui/test/Opa5",
+    "sap/ui/test/matchers/AggregationLengthEquals",
+    "sap/ui/test/matchers/Properties",
+    "sap/ui/test/actions/Press",
+    "sap/ui/test/actions/EnterText",
+    "sap/ui/test/matchers/PropertyStrictEquals",
+  ],
+  function (
+    Opa5,
+    AggregationLengthEquals,
+    Properties,
+    Press,
+    EnterText,
+    PropertyStrictEquals
+  ) {
+    "use strict";
 
-        const NOME_VIEW = "ListaRacas",
-            ID_PAGINA = "paginaListaDeRacas",
-            ID_LISTA = "listaDeRacas",
-            ID_ITEM_LIST = "customListItemRaca",
-            ID_SEARCH_FIELD = "searchFieldRacas",
-            ID_BOTAO_RESET = "resetBtn",
-            TITULO_DA_PAGINA = "O Senhor dos Anéis";
-        Opa5.createPageObjects({
-            naPaginaDaListaDeRacas: {
-                actions: {
-                    euApertoParaCarregarMaisItensDaListaDeRacas: function () {
-                        return this.waitFor({
-                            id: ID_LISTA,
-                            viewName: NOME_VIEW,
-                            actions: new Press(),
-                            errorMessage:
-                                "A Lista de raças não tem a opção de listar mais itens",
-                        });
-                    },
-                    euDigitoONomeDeUmaRacaNoSearchField: function (nomeDaRaca) {
-                        return this.waitFor({
-                            id: ID_SEARCH_FIELD,
-                            viewName: NOME_VIEW,
-                            actions: new EnterText({
-                                text: nomeDaRaca,
-                            }),
-                            errorMessage: "SearchField não encontrado.",
-                        });
-                    },
-                    euPressionoBotaoReset: function () {
-                        return this.waitFor({
-                            id: ID_BOTAO_RESET,
-                            viewName: NOME_VIEW,
-                            actions: new Press(),
-                            errorMessage:
-                                "Não foi possível encontrar ou pressionar o botão reset",
-                        });
-                    },
-                    euPressionoBotaoVoltar: function () {
-                        return this.waitFor({
-                            id: ID_PAGINA,
-                            viewName: NOME_VIEW,
-                            actions: new Press(),
-                            errorMessage:
-                                "Não foi possível encontrar o botão voltar na página",
-                        });
-                    },
-                    euSelecionoUmaRacaNaLista: function (racaSelecionada) {
-                        return this.waitFor({
-                            controlType: "sap.m.ObjectIdentifier",
-                            viewName: NOME_VIEW,
-                            matchers: new Properties({
-                                title: racaSelecionada,
-                            }),
-                            actions: new Press(),
-                            errorMessage: "Não foi possível selecionar o item na lista",
-                        });
-                    },
-                    euPressionoOBotaoAdicionar: function () {
-                        return this.waitFor({
-                            controlType: "sap.m.Button",
-                            matchers: new PropertyStrictEquals({
-                                name: "type",
-                                value: "Accept",
-                            }),
-                            actions: new Press(),
-                            success: function () {
-                                Opa5.assert.ok(true, "O botão adicionar foi pressionado");
-                            },
-                            errorMessage: "Não foi possível encontrar o botao adicionar",
-                        })
-                    },
-                },
-                assertions: {
-                    oTituloDaPaginaDeRacasDeveraSer: function () {
-                        return this.waitFor({
-                            success: function () {
-                                return this.waitFor({
-                                    id: ID_PAGINA,
-                                    viewName: NOME_VIEW,
-                                    matchers: new Properties({
-                                        title: TITULO_DA_PAGINA,
-                                    }),
-                                    success: function (pagina) {
-                                        Opa5.assert.ok(pagina, "O título da página está correto.");
-                                    },
-                                    errorMessage:
-                                        "Não foi encontrado título correspondente a 'O Senhor dos Anéis' ou não foi possível navegar até a página",
-                                });
-                            },
-                        });
-                    },
-                    aUrlDaPaginaDeRacasDeveraSer: function () {
-                        return this.waitFor({
-                            success: function () {
-                                const hash = Opa5.getHashChanger().getHash();
-                                Opa5.assert.strictEqual(
-                                    hash,
-                                    "racas",
-                                    "Navegou para a pagina de racas"
-                                );
-                            },
-                            errorMessage: "A URL é diferente da esperada",
-                        });
-                    },
-                    aListaDeveApresentar10Racas: function () {
-                        return this.waitFor({
-                            id: ID_LISTA,
-                            viewName: NOME_VIEW,
-                            matchers: new AggregationLengthEquals({
-                                name: "items",
-                                length: 10,
-                            }),
-                            success: function () {
-                                Opa5.assert.ok(true, "A lista contem 10 raças");
-                            },
-                            errorMessage:
-                                "A lista nao contem 10 raças ou não foi possível verificar o seu tamanho",
-                        });
-                    },
-                    aListaDeveApresentar5Racas: function () {
-                        return this.waitFor({
-                            id: ID_LISTA,
-                            viewName: NOME_VIEW,
-                            matchers: new AggregationLengthEquals({
-                                name: "items",
-                                length: 5,
-                            }),
-                            success: function () {
-                                Opa5.assert.ok(true, "A lista contem 5 raças");
-                            },
-                            errorMessage:
-                                "A lista nao contem 5 raças ou não foi possível verificar o seu tamanho",
-                        });
-                    },
-                    aListaDeveApresentarApenas1Raca: function () {
-                        return this.waitFor({
-                            id: ID_LISTA,
-                            viewName: NOME_VIEW,
-                            matchers: new AggregationLengthEquals({
-                                name: "items",
-                                length: 1,
-                            }),
-                            success: function () {
-                                Opa5.assert.ok(true, "A lista contem apenas 1 raça");
-                            },
-                            errorMessage:
-                                "A lista nao contem apenas 1 raça ou não foi possível verificar o seu tamanho",
-                        });
-                    },
-                    aListaDeveEstarVazia: function () {
-                        return this.waitFor({
-                            id: ID_LISTA,
-                            viewName: NOME_VIEW,
-                            matchers: new AggregationLengthEquals({
-                                name: "items",
-                                length: 0,
-                            }),
-                            success: function () {
-                                Opa5.assert.ok(true, "A lista está vazia");
-                            },
-                            errorMessage:
-                                "A lista nao está vazia ou não foi possível verificar o seu tamanho",
-                        });
-                    },
-                    euVerificoSeAListaTem10Registros: function (){
-                        return this.waitFor({
-                            id: ID_LISTA,
-                            viewName: NOME_VIEW,
-                            success: function (lista) {
-                                const modeloDaLista = lista.getModel("racas");
-                                const listaDeRacas = modeloDaLista.getProperty("/");
-                                if(listaDeRacas.length === 10) {
-                                    Opa5.assert.ok(true, "A lista tem 10 registros");
-                                }
-                            },
-                            errorMessage: "A lista não contem 10 registros",
-                        });
-                    },
-                },
-            },
-        });
-    }
+    const NOME_VIEW = "ListaRacas",
+      ID_PAGINA = "paginaListaDeRacas",
+      ID_LISTA = "listaDeRacas",
+      ID_ITEM_LIST = "customListItemRaca",
+      ID_SEARCH_FIELD = "searchFieldRacas",
+      ID_BOTAO_RESET = "resetBtn",
+      TITULO_DA_PAGINA = "O Senhor dos Anéis";
+    Opa5.createPageObjects({
+      naPaginaDaListaDeRacas: {
+        actions: {
+          euApertoParaCarregarMaisItensDaListaDeRacas: function () {
+            return this.waitFor({
+              id: ID_LISTA,
+              viewName: NOME_VIEW,
+              actions: new Press(),
+              errorMessage:
+                "A Lista de raças não tem a opção de listar mais itens",
+            });
+          },
+          euDigitoONomeDeUmaRacaNoSearchField: function (nomeDaRaca) {
+            return this.waitFor({
+              id: ID_SEARCH_FIELD,
+              viewName: NOME_VIEW,
+              actions: new EnterText({
+                text: nomeDaRaca,
+              }),
+              errorMessage: "SearchField não encontrado.",
+            });
+          },
+          euPressionoBotaoReset: function () {
+            return this.waitFor({
+              id: ID_BOTAO_RESET,
+              viewName: NOME_VIEW,
+              actions: new Press(),
+              errorMessage:
+                "Não foi possível encontrar ou pressionar o botão reset",
+            });
+          },
+          euPressionoBotaoVoltar: function () {
+            return this.waitFor({
+              id: ID_PAGINA,
+              viewName: NOME_VIEW,
+              actions: new Press(),
+              errorMessage:
+                "Não foi possível encontrar o botão voltar na página",
+            });
+          },
+          euSelecionoUmaRacaNaLista: function (racaSelecionada) {
+            return this.waitFor({
+              controlType: "sap.m.ObjectIdentifier",
+              viewName: NOME_VIEW,
+              matchers: new Properties({
+                title: racaSelecionada,
+              }),
+              actions: new Press(),
+              errorMessage: "Não foi possível selecionar o item na lista",
+            });
+          },
+          euPressionoOBotaoAdicionar: function () {
+            return this.waitFor({
+              controlType: "sap.m.Button",
+              matchers: new PropertyStrictEquals({
+                name: "type",
+                value: "Accept",
+              }),
+              actions: new Press(),
+              success: function () {
+                Opa5.assert.ok(true, "O botão adicionar foi pressionado");
+              },
+              errorMessage: "Não foi possível encontrar o botao adicionar",
+            });
+          },
+          euPressionoOkNaMessageBoxDeSucesso: function () {
+            return this.waitFor({
+              searchOpenDialogs: true,
+              controlType: "sap.m.Button",
+              matchers: new Properties({
+                text: "OK",
+              }),
+              actions: new Press(),
+              errorMessage:
+                "Não foi possível pressionar o botão 'OK' para fechar o diálogo",
+            });
+          },
+        },
+        assertions: {
+          oTituloDaPaginaDeRacasDeveraSer: function () {
+            return this.waitFor({
+              success: function () {
+                return this.waitFor({
+                  id: ID_PAGINA,
+                  viewName: NOME_VIEW,
+                  matchers: new Properties({
+                    title: TITULO_DA_PAGINA,
+                  }),
+                  success: function (pagina) {
+                    Opa5.assert.ok(pagina, "O título da página está correto.");
+                  },
+                  errorMessage:
+                    "Não foi encontrado título correspondente a 'O Senhor dos Anéis' ou não foi possível navegar até a página",
+                });
+              },
+            });
+          },
+          aUrlDaPaginaDeRacasDeveraSer: function () {
+            return this.waitFor({
+              success: function () {
+                const hash = Opa5.getHashChanger().getHash();
+                Opa5.assert.strictEqual(
+                  hash,
+                  "racas",
+                  "Navegou para a pagina de racas"
+                );
+              },
+              errorMessage: "A URL é diferente da esperada",
+            });
+          },
+          aListaDeveApresentar10Racas: function () {
+            return this.waitFor({
+              id: ID_LISTA,
+              viewName: NOME_VIEW,
+              matchers: new AggregationLengthEquals({
+                name: "items",
+                length: 10,
+              }),
+              success: function () {
+                Opa5.assert.ok(true, "A lista contem 10 raças");
+              },
+              errorMessage:
+                "A lista nao contem 10 raças ou não foi possível verificar o seu tamanho",
+            });
+          },
+          aListaDeveApresentar5Racas: function () {
+            return this.waitFor({
+              id: ID_LISTA,
+              viewName: NOME_VIEW,
+              matchers: new AggregationLengthEquals({
+                name: "items",
+                length: 5,
+              }),
+              success: function () {
+                Opa5.assert.ok(true, "A lista contem 5 raças");
+              },
+              errorMessage:
+                "A lista nao contem 5 raças ou não foi possível verificar o seu tamanho",
+            });
+          },
+          aListaDeveApresentarApenas1Raca: function () {
+            return this.waitFor({
+              id: ID_LISTA,
+              viewName: NOME_VIEW,
+              matchers: new AggregationLengthEquals({
+                name: "items",
+                length: 1,
+              }),
+              success: function () {
+                Opa5.assert.ok(true, "A lista contem apenas 1 raça");
+              },
+              errorMessage:
+                "A lista nao contem apenas 1 raça ou não foi possível verificar o seu tamanho",
+            });
+          },
+          aListaDeveEstarVazia: function () {
+            return this.waitFor({
+              id: ID_LISTA,
+              viewName: NOME_VIEW,
+              matchers: new AggregationLengthEquals({
+                name: "items",
+                length: 0,
+              }),
+              success: function () {
+                Opa5.assert.ok(true, "A lista está vazia");
+              },
+              errorMessage:
+                "A lista nao está vazia ou não foi possível verificar o seu tamanho",
+            });
+          },
+          euVerificoSeAListaTem10Registros: function () {
+            return this.waitFor({
+              id: ID_LISTA,
+              viewName: NOME_VIEW,
+              success: function (lista) {
+                const modeloDaLista = lista.getModel("racas");
+                const listaDeRacas = modeloDaLista.getProperty("/");
+                if (listaDeRacas.length === 10) {
+                  Opa5.assert.ok(true, "A lista tem 10 registros");
+                }
+              },
+              errorMessage: "A lista não contem 10 registros",
+            });
+          },
+        },
+      },
+    });
+  }
 );

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/BaseController.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/BaseController.js
@@ -208,8 +208,6 @@ sap.ui.define(
             title: titulo,
             dependentOn: this.getView(),
           });
-          const tempoParaVisualizarMensagem = 2000;
-          setTimeout(() => this.onNavBack(), tempoParaVisualizarMensagem);
         },
         criarDialogoDeErro: function (titulo, detalhes, mensagemDeErro) {
           MessageBox.error(mensagemDeErro, {

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/CriarRaca.controller.js
@@ -1,195 +1,195 @@
 sap.ui.define(
-    [
-        "../controller/BaseController",
-        "ui5/o_senhor_dos_aneis/services/RacaService",
-        "sap/ui/model/json/JSONModel",
-        "sap/m/MessageBox",
-        "ui5/o_senhor_dos_aneis/model/formatter",
-    ],
-    function (BaseController, RacaService, JSONModel, MessageBox, formatter) {
-        "use strict";
-        const ID_INPUT_NOME = "inputNome",
-            ID_RADIO_BTN_EXTINTAOUNAO = "radioBtnExtintaOuNao",
-            MODELO_RACA = "raca";
-        return BaseController.extend(
-            "ui5.o_senhor_dos_aneis.controller.CriarRaca",
-            {
-                formatter: formatter,
+  [
+    "../controller/BaseController",
+    "ui5/o_senhor_dos_aneis/services/RacaService",
+    "sap/ui/model/json/JSONModel",
+    "sap/m/MessageBox",
+    "ui5/o_senhor_dos_aneis/model/formatter",
+  ],
+  function (BaseController, RacaService, JSONModel, MessageBox, formatter) {
+    "use strict";
+    const ID_INPUT_NOME = "inputNome",
+      ID_RADIO_BTN_EXTINTAOUNAO = "radioBtnExtintaOuNao",
+      MODELO_RACA = "raca";
+    return BaseController.extend(
+      "ui5.o_senhor_dos_aneis.controller.CriarRaca",
+      {
+        formatter: formatter,
 
-                onInit: function () {
-                    const rotaCriacao = "criarRaca";
-                    const rotaEdicao = "editarRaca";
-                    this.vincularRota(rotaCriacao, this.aoCoincidirRotaCriar);
-                    this.vincularRota(rotaEdicao, this.aoCoincidirRotaEditar);
-                },
+        onInit: function () {
+          const rotaCriacao = "criarRaca";
+          const rotaEdicao = "editarRaca";
+          this.vincularRota(rotaCriacao, this.aoCoincidirRotaCriar);
+          this.vincularRota(rotaEdicao, this.aoCoincidirRotaEditar);
+        },
 
-                aoCoincidirRotaCriar: function (oEvent) {
-                    this.filtros = {};
-                    this.raca = {};
-                    this.errosDeValidacao = {};
-                    this.modoEditar = false;
-                    this._limparInputs();
-                    this._atualizarTextoDaPaginaCriar();
-                },
+        aoCoincidirRotaCriar: function (oEvent) {
+          this.filtros = {};
+          this.raca = {};
+          this.errosDeValidacao = {};
+          this.modoEditar = false;
+          this._limparInputs();
+          this._atualizarTextoDaPaginaCriar();
+        },
 
-                aoCoincidirRotaEditar: function (oEvent) {
-                    this.filtros = {};
-                    this.raca = {};
-                    this.errosDeValidacao = {};
-                    this.modoEditar = true;
-                    this._limparInputs();
-                    this._carregarDadosDaRacaSelecionada(oEvent);
-                    this._atualizarTextoDaPaginaEditar();
-                },
+        aoCoincidirRotaEditar: function (oEvent) {
+          this.filtros = {};
+          this.raca = {};
+          this.errosDeValidacao = {};
+          this.modoEditar = true;
+          this._limparInputs();
+          this._carregarDadosDaRacaSelecionada(oEvent);
+          this._atualizarTextoDaPaginaEditar();
+        },
 
-                aoMudarNome: function (oEvent) {
-                    this._aoMudarInput(oEvent, this._validarNome.bind(this));
-                },
+        aoMudarNome: function (oEvent) {
+          this._aoMudarInput(oEvent, this._validarNome.bind(this));
+        },
 
-                aoCriarRaca: async function (oEvent) {
-                    this._pegarValoresDaRacaNaTela();
-                    if (!this.modoEditar) {
-                        if (this._validarNovaRaca(this.raca)) {
-                            try {
-                                const racaCriada = await RacaService.adicionarRaca(this.raca);
-                                const mensagemDeSucesso = "Raça adicionada com sucesso!";
-                                const tituloDaMessageBox = "Sucesso";
-                                this.criarDialogoDeSucesso(
-                                    mensagemDeSucesso,
-                                    tituloDaMessageBox
-                                );
-                                this._limparInputs();
-                            } catch (erros) {
-                                this._exibirErros(erros);
-                            }
-                        }
-                        return;
-                    }
-                    if (this._validarNovaRaca(this.raca)) {
-                        try {
-                            const racaEditada = await RacaService.editarRaca(this.raca);
-                            const mensagemDeSucesso = "Raça editada com sucesso!";
-                            const tituloDaMessageBox = "Sucesso";
-                            this.criarDialogoDeSucesso(mensagemDeSucesso, tituloDaMessageBox);
-                            this._limparInputs();
-                        } catch (erros) {
-                            this._exibirErros(erros);
-                        }
-                    }
-                },
-
-                onNavToListaDeRacas: function () {
-                    const rotaListaDeRacas = "listaDeRacas";
-                    this.onNavTo(rotaListaDeRacas);
-                },
-
-                _carregarDadosDaRacaSelecionada: async function (oEvent) {
-                    if (oEvent.getParameter("arguments").id) {
-                        try {
-                            const idRaca = oEvent.getParameter("arguments").id;
-                            const raca = await RacaService.obterRaca(idRaca);
-                            const modelo = new JSONModel(raca);
-
-                            this.getView().setModel(modelo, MODELO_RACA);
-                        } catch (erros) {
-                            this._exibirErros(erros);
-                        }
-                    }
-                },
-
-                _atualizarTextoDaPaginaCriar: function () {
-                    this._atualizarTituloDaPaginaCriar();
-                    this._atualizarLabelDoBotaoAdicionar();
-                },
-
-                _atualizarTextoDaPaginaEditar: function () {
-                    this._atualizarTituloDaPaginaEditar();
-                    this._atualizarLabelDoBotaoEditar();
-                },
-
-                _atualizarTituloDaPaginaCriar: function () {
-                    const idPaginaCriacao = "paginaCriarRaca";
-                    const chaveI18N = "TituloPaginaCriarRaca";
-                    this.byId(idPaginaCriacao).setTitle(this.obterTextoI18N(chaveI18N));
-                },
-
-                _atualizarTituloDaPaginaEditar: function () {
-                    const idPaginaCriacao = "paginaCriarRaca";
-                    const chaveI18N = "TituloPaginaEditarRaca";
-                    this.byId(idPaginaCriacao).setTitle(this.obterTextoI18N(chaveI18N));
-                },
-
-                _atualizarLabelDoBotaoAdicionar: function () {
-                    const idBotaoAdicionar = "criarRacaBtn";
-                    const chaveI18N = "BotaoAdicionar";
-                    this.byId(idBotaoAdicionar).setText(this.obterTextoI18N(chaveI18N));
-                },
-
-                _atualizarLabelDoBotaoEditar: function () {
-                    const idBotaoAdicionar = "criarRacaBtn";
-                    const chaveI18N = "BotaoEditar";
-                    this.byId(idBotaoAdicionar).setText(this.obterTextoI18N(chaveI18N));
-                },
-
-                _aoMudarInput: function (oEvent, funcaoDeValidacao) {
-                    const objeto = oEvent.getSource();
-                    const nomeInserido = objeto.getValue();
-                    let valueState = funcaoDeValidacao(nomeInserido)
-                        ? "Success"
-                        : "Error";
-                    objeto.setValueState(valueState);
-                },
-
-                _validarNovaRaca: function (raca) {
-                    let racaValida = false;
-                    const nomeInseridoInput = this._validarNome(raca.nome);
-                    if (nomeInseridoInput) {
-                        racaValida = true;
-                        return racaValida;
-                    }
-                    this._exibirErros(this.errosDeValidacao);
-                    return racaValida;
-                },
-
-                _pegarValoresDaRacaNaTela: function () {
-                    const modelo = this.getView().getModel("raca");
-
-                    const dadosDoModelo = modelo.getData();
-                    const condicaoExtinta = 0;
-                    const condicaoEstaExtintaNoModelo =
-                        this.byId(ID_RADIO_BTN_EXTINTAOUNAO).getSelectedIndex() ==
-                        condicaoExtinta
-                            ? true
-                            : false;
-
-                    this.raca = {
-                        id: dadosDoModelo.id,
-                        nome: dadosDoModelo.nome,
-                        localizacaoGeografica: dadosDoModelo.localizacaoGeografica,
-                        habilidadeRacial: dadosDoModelo.habilidadeRacial,
-                        estaExtinta: condicaoEstaExtintaNoModelo,
-                    };
-                },
-
-                _limparInputs: function () {
-                    const stringVazia = "";
-                    const condicaoInicial = 0;
-                    const valueStatePadrao = "None";
-
-
-                    const modelo = new JSONModel({
-                        nome: stringVazia,
-                        localizacaoGeografica: stringVazia,
-                        habilidadeRacial: stringVazia,
-                    });
-                    this.getView().setModel(modelo, MODELO_RACA);
-
-                    this.byId(ID_INPUT_NOME).setValueState(valueStatePadrao);
-                    this.byId(ID_RADIO_BTN_EXTINTAOUNAO).setSelectedIndex(
-                        condicaoInicial
-                    );
-                },
+        aoCriarRaca: async function (oEvent) {
+          this._pegarValoresDaRacaNaTela();
+          if (!this.modoEditar) {
+            if (this._validarNovaRaca(this.raca)) {
+              try {
+                const racaCriada = await RacaService.adicionarRaca(this.raca);
+                const mensagemDeSucesso = "Raça adicionada com sucesso!";
+                const tituloDaMessageBox = "Sucesso";
+                this.criarDialogoDeSucesso(
+                  mensagemDeSucesso,
+                  tituloDaMessageBox
+                );
+                this._limparInputs();
+                this.onNavToListaDeRacas();
+              } catch (erros) {
+                this._exibirErros(erros);
+              }
             }
-        );
-    }
+            return;
+          }
+          if (this._validarNovaRaca(this.raca)) {
+            try {
+              const racaEditada = await RacaService.editarRaca(this.raca);
+              const mensagemDeSucesso = "Raça editada com sucesso!";
+              const tituloDaMessageBox = "Sucesso";
+              this.criarDialogoDeSucesso(mensagemDeSucesso, tituloDaMessageBox);
+              this._limparInputs();
+            } catch (erros) {
+              this._exibirErros(erros);
+            }
+          }
+        },
+
+        onNavToListaDeRacas: function () {
+          const rotaListaDeRacas = "listaDeRacas";
+          this.onNavTo(rotaListaDeRacas);
+        },
+
+        _carregarDadosDaRacaSelecionada: async function (oEvent) {
+          if (oEvent.getParameter("arguments").id) {
+            try {
+              const idRaca = oEvent.getParameter("arguments").id;
+              const raca = await RacaService.obterRaca(idRaca);
+              const modelo = new JSONModel(raca);
+
+              this.getView().setModel(modelo, MODELO_RACA);
+            } catch (erros) {
+              this._exibirErros(erros);
+            }
+          }
+        },
+
+        _atualizarTextoDaPaginaCriar: function () {
+          this._atualizarTituloDaPaginaCriar();
+          this._atualizarLabelDoBotaoAdicionar();
+        },
+
+        _atualizarTextoDaPaginaEditar: function () {
+          this._atualizarTituloDaPaginaEditar();
+          this._atualizarLabelDoBotaoEditar();
+        },
+
+        _atualizarTituloDaPaginaCriar: function () {
+          const idPaginaCriacao = "paginaCriarRaca";
+          const chaveI18N = "TituloPaginaCriarRaca";
+          this.byId(idPaginaCriacao).setTitle(this.obterTextoI18N(chaveI18N));
+        },
+
+        _atualizarTituloDaPaginaEditar: function () {
+          const idPaginaCriacao = "paginaCriarRaca";
+          const chaveI18N = "TituloPaginaEditarRaca";
+          this.byId(idPaginaCriacao).setTitle(this.obterTextoI18N(chaveI18N));
+        },
+
+        _atualizarLabelDoBotaoAdicionar: function () {
+          const idBotaoAdicionar = "criarRacaBtn";
+          const chaveI18N = "BotaoAdicionar";
+          this.byId(idBotaoAdicionar).setText(this.obterTextoI18N(chaveI18N));
+        },
+
+        _atualizarLabelDoBotaoEditar: function () {
+          const idBotaoAdicionar = "criarRacaBtn";
+          const chaveI18N = "BotaoEditar";
+          this.byId(idBotaoAdicionar).setText(this.obterTextoI18N(chaveI18N));
+        },
+
+        _aoMudarInput: function (oEvent, funcaoDeValidacao) {
+          const objeto = oEvent.getSource();
+          const nomeInserido = objeto.getValue();
+          let valueState = funcaoDeValidacao(nomeInserido)
+            ? "Success"
+            : "Error";
+          objeto.setValueState(valueState);
+        },
+
+        _validarNovaRaca: function (raca) {
+          let racaValida = false;
+          const nomeInseridoInput = this._validarNome(raca.nome);
+          if (nomeInseridoInput) {
+            racaValida = true;
+            return racaValida;
+          }
+          this._exibirErros(this.errosDeValidacao);
+          return racaValida;
+        },
+
+        _pegarValoresDaRacaNaTela: function () {
+          const modelo = this.getView().getModel("raca");
+
+          const dadosDoModelo = modelo.getData();
+          const condicaoExtinta = 0;
+          const condicaoEstaExtintaNoModelo =
+            this.byId(ID_RADIO_BTN_EXTINTAOUNAO).getSelectedIndex() ==
+            condicaoExtinta
+              ? true
+              : false;
+
+          this.raca = {
+            id: dadosDoModelo.id,
+            nome: dadosDoModelo.nome,
+            localizacaoGeografica: dadosDoModelo.localizacaoGeografica,
+            habilidadeRacial: dadosDoModelo.habilidadeRacial,
+            estaExtinta: condicaoEstaExtintaNoModelo,
+          };
+        },
+
+        _limparInputs: function () {
+          const stringVazia = "";
+          const condicaoInicial = 0;
+          const valueStatePadrao = "None";
+
+          const modelo = new JSONModel({
+            nome: stringVazia,
+            localizacaoGeografica: stringVazia,
+            habilidadeRacial: stringVazia,
+          });
+          this.getView().setModel(modelo, MODELO_RACA);
+
+          this.byId(ID_INPUT_NOME).setValueState(valueStatePadrao);
+          this.byId(ID_RADIO_BTN_EXTINTAOUNAO).setSelectedIndex(
+            condicaoInicial
+          );
+        },
+      }
+    );
+  }
 );

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/DetalhesRaca.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/DetalhesRaca.controller.js
@@ -62,6 +62,9 @@ sap.ui.define(
               const mensagemDeSucesso = "Raça removida com sucesso!";
               const tituloDaMessageBox = "Sucesso";
               this.criarDialogoDeSucesso(mensagemDeSucesso, tituloDaMessageBox);
+              const tempoParaVisualizarMensagem = 2000;
+              const rota = "listaDeRacas";
+              setTimeout(() => this.onNavTo(rota), tempoParaVisualizarMensagem);
             } catch (erros) {
               this._exibirErros(erros);
             }
@@ -97,6 +100,7 @@ sap.ui.define(
               this._exibirErros(erros);
             }
           }
+          await this._loadPersonagens();
         },
 
         aoSelecionarItemNaListaDePersonagem: function (oEvent) {
@@ -118,6 +122,7 @@ sap.ui.define(
                   tituloDaMessageBox
                 );
                 this._limparInputs(oEvent);
+
                 return this.byId(ID_MODAL_CRIAR_PERSONAGEM).close();
               } catch (erros) {
                 return this._exibirErros(erros);
@@ -135,12 +140,21 @@ sap.ui.define(
               this._exibirErros(erros);
             }
           }
+          await this._loadPersonagens();
         },
 
-        aoClicarBtnCancelarNoModal: function (oEvent) {
-          this.byId(ID_MODAL_CRIAR_PERSONAGEM).close();
-          this._limparInputs(oEvent);
-          this._mostrarBotoesDeEditarERemoverPersonagem(false);
+        aoClicarBtnCancelarNoModal: async function (oEvent) {
+          const tituloDoDialogo = "Cancelar operação",
+            mensagemDoDialogo = "Deseja realmente cancelar a operação?";
+          const confirmacao = await this.criarDialogoDeAviso(
+            tituloDoDialogo,
+            mensagemDoDialogo
+          );
+          if (confirmacao) {
+            this.byId(ID_MODAL_CRIAR_PERSONAGEM).close();
+            this._limparInputs(oEvent);
+            this._mostrarBotoesDeEditarERemoverPersonagem(false);
+          }
         },
 
         _carregarModalDeCriacao: async function () {
@@ -334,6 +348,21 @@ sap.ui.define(
         _mostrarBotoesDeEditarERemoverPersonagem: function (visibilidade) {
           this.byId("removerPersonagemBtn").setVisible(visibilidade);
           this.byId("editarPersonagemBtn").setVisible(visibilidade);
+        },
+        _loadPersonagens: async function () {
+          try {
+            const idRaca = this.getView().getModel(MODELO_RACA).getData().id;
+            const raca = await RacaService.obterRaca(idRaca);
+            this.filtros.nomeDaRaca = raca.nome;
+            const personagens = await PersonagemService.obterTodos(
+              this.filtros
+            );
+
+            const modeloPersonagens = new JSONModel(personagens);
+            this.getView().setModel(modeloPersonagens, MODELO_PERSONAGENS);
+          } catch (erros) {
+            this._exibirErros(erros);
+          }
         },
       }
     );

--- a/Cod3rsGrowth.Web/wwwroot/webapp/controller/DetalhesRaca.controller.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/controller/DetalhesRaca.controller.js
@@ -77,6 +77,28 @@ sap.ui.define(
           this._carregarModalDeCriacao();
         },
 
+        aoClicarBtnRemoverPersonagem: async function () {
+          const tituloDoDialogo = "Excluir registro",
+            mensagemDoDialogo = "Deseja confirmar a exclusão desse registro?";
+          const confirmacao = await this.criarDialogoDeAviso(
+            tituloDoDialogo,
+            mensagemDoDialogo
+          );
+          if (confirmacao) {
+            const idPersonagem = this.getView()
+              .getModel(MODELO_PERSONAGEM)
+              .getData().id;
+            try {
+              await PersonagemService.removerPersonagem(idPersonagem);
+              const mensagemDeSucesso = "Personagem removido com sucesso!";
+              const tituloDaMessageBox = "Sucesso";
+              this.criarDialogoDeSucesso(mensagemDeSucesso, tituloDaMessageBox);
+            } catch (erros) {
+              this._exibirErros(erros);
+            }
+          }
+        },
+
         aoSelecionarItemNaListaDePersonagem: function (oEvent) {
           this._buscarDadosDoPersonagemSelecionadoNaLista(oEvent);
           this._mostrarBotoesDeEditarERemoverPersonagem(true);

--- a/Cod3rsGrowth.Web/wwwroot/webapp/services/PersonagemService.js
+++ b/Cod3rsGrowth.Web/wwwroot/webapp/services/PersonagemService.js
@@ -6,6 +6,8 @@ sap.ui.define(["sap/m/MessageBox"], function (MessageBox) {
   const URL_POST_PERSONAGEM =
     "https://localhost:7244/api/Personagem/personagem";
   const URL_PUT_PERSONAGEM = "https://localhost:7244/api/Personagem/personagem";
+  const URL_DELETE_PERSONAGEM =
+    "https://localhost:7244/api/Personagem/personagem";
 
   return {
     obterTodos: async function (filtros) {
@@ -54,6 +56,27 @@ sap.ui.define(["sap/m/MessageBox"], function (MessageBox) {
         const response = await fetch(urlPersonagens.href, {
           method: "PUT",
           body: JSON.stringify(personagem),
+          headers: {
+            "Content-type": "application/json; charset=UTF-8",
+          },
+        });
+        if (!response.ok) {
+          throw await response.json();
+        }
+        if (response.status == 200) {
+          return;
+        }
+        return await response.json();
+      } catch (erro) {
+        throw erro;
+      }
+    },
+    removerPersonagem: async function (idPersonagem) {
+      let urlPersonagens = new URL(URL_DELETE_PERSONAGEM);
+      try {
+        const response = await fetch(urlPersonagens.href, {
+          method: "DELETE",
+          body: JSON.stringify(idPersonagem),
           headers: {
             "Content-type": "application/json; charset=UTF-8",
           },


### PR DESCRIPTION
Adicionado um botão na tela de detalhes do registro pai para permitir a remoção dos registros filhos.

Ao clicar no botão correspondente a um registro filho, abre uma modal ou diálogo para confirmar a remoção do registro filho.

Implementada a lógica na controller para enviar a solicitação de remoção para a API quando o usuário confirmar a remoção na modal.

Escrito testes OPA para verificar se a remoção dos registros filhos através da modal está funcionando corretamente e se a solicitação é enviada para a API conforme esperado.